### PR TITLE
add license indication about VRMLoaderUI

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -17,7 +17,9 @@ XinputGamePad: https://github.com/kaikikazu/XinputGamePad
 UniRx: https://github.com/neuecc/UniRx
         
 unity-transform-control: https://github.com/mattatz/unity-transform-control
-        
+
+VRMLoaderUI: https://github.com/m2wasabi/VRMLoaderUI
+
 Newtonsoft.Json: https://www.newtonsoft.com/json
         
 OVRLipSync: https://developer.oculus.com/licenses/audio-3.2.2/
@@ -189,6 +191,31 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+        
+        VRMLoaderUI
+
+MIT License
+
+Copyright (c) 2018 m2wasabi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.        
+        
         
         Newtonsoft.Json
         


### PR DESCRIPTION
VRMLoaderUIを統合したため、OSSライセンス一覧に追記した。

下記issueのfixに対応する。

https://github.com/malaybaku/VMagicMirror/issues/31

またPRとしては下記に対応する。

https://github.com/malaybaku/VMagicMirror/pull/36