### PR TITLE
feature/shadow on screen

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageFactory.cs
@@ -161,6 +161,14 @@ namespace Baku.VMagicMirrorConfig
 
         public Message LightColor(int r, int g, int b) => WithArg($"{r},{g},{b}");
         public Message LightIntensity(int intensityPercent) => WithArg($"{intensityPercent}");
+        public Message LightYaw(int angleDeg) => WithArg($"{angleDeg}");
+        public Message LightPitch(int angleDeg) => WithArg($"{angleDeg}");
+
+        public Message ShadowEnable(bool enable) => WithArg($"{enable}");
+        public Message ShadowIntensity(int intensityPercent) => WithArg($"{intensityPercent}");
+        public Message ShadowYaw(int angleDeg) => WithArg($"{angleDeg}");
+        public Message ShadowPitch(int angleDeg) => WithArg($"{angleDeg}");
+        public Message ShadowDepthOffset(int depthCentimeter) => WithArg($"{depthCentimeter}");
 
         public Message BloomColor(int r, int g, int b) => WithArg($"{r},{g},{b}");
         public Message BloomIntensity(int intensityPercent) => WithArg($"{intensityPercent}");

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -156,6 +156,17 @@
     <!-- Light Setting -->
     <sys:String x:Key="Light">Light</sys:String>
     <sys:String x:Key="Light_Intensity">Intensity [%]</sys:String>
+    <sys:String x:Key="Light_Yaw">Yaw Angle [deg]</sys:String>
+    <sys:String x:Key="Light_Pitch">Pitch Angle [deg]</sys:String>
+
+    <sys:String x:Key="Shadow">Shadow</sys:String>
+    <sys:String x:Key="Shadow_Enable">Enable Shadow</sys:String>
+    <sys:String x:Key="Shadow_Enable_Streaming">Avatar's Shadow</sys:String>
+    <sys:String x:Key="Shadow_Intensity">Intensity [%]</sys:String>
+    <sys:String x:Key="Shadow_Yaw">Yaw Angle [deg]</sys:String>
+    <sys:String x:Key="Shadow_Pitch">Pitch Angle [deg]</sys:String>
+    <sys:String x:Key="Shadow_DepthOffset">Depth Offset [cm]</sys:String>
+    
     <sys:String x:Key="Bloom">Bloom</sys:String>
     <sys:String x:Key="Bloom_Intensity">Intensity [%]</sys:String>
     <sys:String x:Key="Bloom_Threshold">Threshold [%]</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -153,6 +153,17 @@
     <!-- Light Setting -->
     <sys:String x:Key="Light">ライト</sys:String>
     <sys:String x:Key="Light_Intensity">明るさ[%]</sys:String>
+    <sys:String x:Key="Light_Yaw">向き(横)[deg]</sys:String>
+    <sys:String x:Key="Light_Pitch">向き(上下)[deg]</sys:String>
+
+    <sys:String x:Key="Shadow">影</sys:String>
+    <sys:String x:Key="Shadow_Enable">影を有効化</sys:String>
+    <sys:String x:Key="Shadow_Enable_Streaming">キャラの影</sys:String>
+    <sys:String x:Key="Shadow_Intensity">濃さ[%]</sys:String>
+    <sys:String x:Key="Shadow_Yaw">向き(横)[deg]</sys:String>
+    <sys:String x:Key="Shadow_Pitch">向き(上下)[deg]</sys:String>
+    <sys:String x:Key="Shadow_DepthOffset">奥行きの調整 [cm]</sys:String>
+
     <sys:String x:Key="Bloom">Bloom</sys:String>
     <sys:String x:Key="Bloom_Intensity">強さ[%]</sys:String>
     <sys:String x:Key="Bloom_Threshold">しきい値[%]</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LightSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LightSettingPanel.xaml
@@ -6,7 +6,7 @@
              xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
              mc:Ignorable="d"
-             d:DesignHeight="550"
+             d:DesignHeight="750"
              d:DesignWidth="350"
              d:DataContext="{x:Type vmm:WindowSettingViewModel}"
              >
@@ -51,6 +51,8 @@
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition Height="15"/>
+                            <RowDefinition/>
+                            <RowDefinition/>
                             <RowDefinition/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
@@ -100,9 +102,119 @@
                         <TextBox Grid.Row="4" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderLightIntensity}"
                                  />
+
+                        <TextBlock Grid.Row="5" Grid.Column="0"
+                                   Text="{DynamicResource Light_Yaw}" />
+                        <Slider Grid.Row="5" Grid.Column="1"
+                                x:Name="sliderLightYaw"
+                                Minimum="-180"
+                                Maximum="180"
+                                Value="{Binding LightYaw, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="5" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderLightYaw}"
+                                 />
+
+                        <TextBlock Grid.Row="6" Grid.Column="0"
+                                   Text="{DynamicResource Light_Pitch}" />
+                        <Slider Grid.Row="6" Grid.Column="1"
+                                x:Name="sliderLightPitch"
+                                Minimum="-90"
+                                Maximum="90"
+                                Value="{Binding LightPitch, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="6" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderLightPitch}"
+                                 />
+
                     </Grid>
                 </StackPanel>
             </md:Card>
+
+            <md:Card>
+                <StackPanel>
+                    <TextBlock Text="{DynamicResource Shadow}"
+                               Margin="5"
+                               Style="{StaticResource HeaderText}"
+                               />
+
+                    <CheckBox Margin="10,5,10,15"
+                              Content="{DynamicResource Shadow_Enable}"
+                              IsChecked="{Binding EnableShadow}"
+                              />
+
+                    <Grid Margin="5"
+                          IsEnabled="{Binding EnableShadow}"
+                          >
+                        <Grid.Resources>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="TextAlignment" Value="Center"/>
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_Intensity}" />
+                        <Slider Grid.Row="0" Grid.Column="1"
+                                x:Name="sliderShadowIntensity"
+                                Minimum="0"
+                                Maximum="100"
+                                Value="{Binding ShadowIntensity, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="0" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderShadowIntensity}"
+                                 />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_Yaw}" />
+                        <Slider Grid.Row="1" Grid.Column="1"
+                                x:Name="sliderShadowYaw"
+                                Minimum="-180"
+                                Maximum="180"
+                                Value="{Binding ShadowYaw, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="1" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderShadowYaw}"
+                                 />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_Pitch}" />
+                        <Slider Grid.Row="2" Grid.Column="1"
+                                x:Name="sliderShadowPitch"
+                                Minimum="-90"
+                                Maximum="90"
+                                Value="{Binding ShadowPitch, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="2" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderShadowPitch}"
+                                 />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_DepthOffset}" />
+                        <Slider Grid.Row="3" Grid.Column="1"
+                                x:Name="sliderShadowDepthOffset"
+                                Minimum="1"
+                                Maximum="150"
+                                Value="{Binding ShadowDepthOffset, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="3" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderShadowDepthOffset}"
+                                 />
+
+                    </Grid>
+                </StackPanel>
+            </md:Card>
+
 
             <md:Card>
                 <StackPanel>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/MainWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/MainWindow.xaml
@@ -9,8 +9,8 @@
         d:DataContext="{x:Type vmm:MainWindowViewModel}"
         Title="VMagicMirror v0.8.2a" 
         ResizeMode="CanMinimize"
-        Height="470" Width="550"
-        MinHeight="470" MinWidth="550"
+        Height="520" Width="550"
+        MinHeight="520" MinWidth="550"
         >
     <Window.DataContext>
         <vmm:MainWindowViewModel/>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/StreamingPanel.xaml
@@ -25,7 +25,7 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0">
-                    <md:Card Margin="5">
+                    <md:Card Margin="5" Height="118">
                         <StackPanel>
 
                             <TextBlock Text="{DynamicResource Streaming_Window}"
@@ -139,17 +139,17 @@
                                        Style="{StaticResource HeaderText}"
                                        />
 
-                            <CheckBox Grid.Row="2" Grid.Column="0"
-                                      Grid.ColumnSpan="3"
-                                      Margin="10,3" 
+                            <CheckBox Margin="10,3" 
                                       Content="{DynamicResource Layout_Hid}"
                                       IsChecked="{Binding LayoutSetting.HidVisibility}"
                                       />
-                            <CheckBox Grid.Row="2" Grid.Column="0"
-                                      Grid.ColumnSpan="3"
-                                      Margin="10,3" 
+                            <CheckBox Margin="10,3" 
                                       Content="{DynamicResource Layout_Gamepad}"
                                       IsChecked="{Binding LayoutSetting.Gamepad.GamepadVisibility}"
+                                      />
+                            <CheckBox Margin="10,3" 
+                                      Content="{DynamicResource Shadow_Enable_Streaming}"
+                                      IsChecked="{Binding LightSetting.EnableShadow}"
                                       />
                         </StackPanel>
                     </md:Card>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
@@ -17,7 +17,7 @@ namespace Baku.VMagicMirrorConfig
             UpdateBloomColor();
         }
 
-        #region ライト
+        #region Light
 
         private int _lightIntensity = 100;
         public int LightIntensity
@@ -29,6 +29,36 @@ namespace Baku.VMagicMirrorConfig
                 {
                     SendMessage(
                         MessageFactory.Instance.LightIntensity(LightIntensity)
+                        );
+                }
+            }
+        }
+
+        private int _lightYaw = 50;
+        public int LightYaw
+        {
+            get => _lightYaw;
+            set
+            {
+                if (SetValue(ref _lightYaw, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.LightYaw(LightYaw)
+                        );
+                }
+            }
+        }
+
+        private int _lightPitch = -30;
+        public int LightPitch
+        {
+            get => _lightPitch;
+            set
+            {
+                if (SetValue(ref _lightPitch, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.LightPitch(LightPitch)
                         );
                 }
             }
@@ -83,6 +113,85 @@ namespace Baku.VMagicMirrorConfig
         {
             LightColor = Color.FromRgb((byte)LightR, (byte)LightG, (byte)LightB);
             SendMessage(MessageFactory.Instance.LightColor(LightR, LightG, LightB));
+        }
+
+        #endregion
+
+        #region Shadow
+
+        private bool _enableShadow = true;
+        public bool EnableShadow
+        {
+            get => _enableShadow;
+            set
+            {
+                if (SetValue(ref _enableShadow, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.ShadowEnable(EnableShadow)
+                        );
+                }
+            }
+        }
+
+        private int _shadowIntensity = 60;
+        public int ShadowIntensity
+        {
+            get => _shadowIntensity;
+            set
+            {
+                if (SetValue(ref _shadowIntensity, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.ShadowIntensity(ShadowIntensity)
+                        );
+                }
+            }
+        }
+
+        private int _shadowYaw = 8;
+        public int ShadowYaw
+        {
+            get => _shadowYaw;
+            set
+            {
+                if (SetValue(ref _shadowYaw, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.ShadowYaw(ShadowYaw)
+                        );
+                }
+            }
+        }
+
+        private int _shadowPitch = -20;
+        public int ShadowPitch
+        {
+            get => _shadowPitch;
+            set
+            {
+                if (SetValue(ref _shadowPitch, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.ShadowPitch(ShadowPitch)
+                        );
+                }
+            }
+        }
+
+        private int _shadowDepthOffset = 40;
+        public int ShadowDepthOffset
+        {
+            get => _shadowDepthOffset;
+            set
+            {
+                if (SetValue(ref _shadowDepthOffset, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.ShadowDepthOffset(ShadowDepthOffset)
+                        );
+                }
+            }
         }
 
         #endregion
@@ -178,6 +287,13 @@ namespace Baku.VMagicMirrorConfig
             LightG = 244;
             LightB = 214;
             LightIntensity = 100;
+            LightYaw = 50;
+            LightPitch = -30;
+
+            EnableShadow = true;
+            ShadowIntensity = 50;
+            ShadowYaw = 15;
+            ShadowPitch = -30;
 
             BloomR = 255;
             BloomG = 255;


### PR DESCRIPTION
影用の設定を追加。ついでに通常のライト設定も追加。

* 影ライト
    * オン/オフ (デフォルト: オン)
    * 影の濃さ[%] (デフォルト: 60)
* 通常ライト / 影ライト共通
    * ヨー、ピッチ角
* 「配信」パネル
    * 「表示」にキャラの影オン/オフを追加

**note:** 通常ライトと影ライトはデフォルトの方向がズレてることに注意 (通常ライトは見下ろし、影ライトはほぼ正面向き)
