### PR TITLE
window transparency UI

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageFactory.cs
@@ -51,7 +51,11 @@ namespace Baku.VMagicMirrorConfig
 
         public Message MoveWindow(int x, int y) => WithArg($"{x},{y}");
         public Message ResetWindowSize() => NoArg();
-        
+
+        public Message SetWholeWindowTransparencyLevel(int level) => WithArg($"{level}");
+
+        public Message SetAlphaValueOnTransparent(int alpha) => WithArg($"{alpha}");
+
         #endregion
 
         #region モーション
@@ -113,6 +117,7 @@ namespace Baku.VMagicMirrorConfig
         public Message EyebrowLeftDownKey(string key) => WithArg(key);
         public Message UseSeparatedKeyForEyebrow(bool separate) => WithArg($"{separate}");
         public Message EyebrowRightUpKey(string key) => WithArg(key);
+
         public Message EyebrowRightDownKey(string key) => WithArg(key);
         public Message EyebrowUpScale(int percentage) => WithArg($"{percentage}");
         public Message EyebrowDownScale(int percentage) => WithArg($"{percentage}");
@@ -123,6 +128,7 @@ namespace Baku.VMagicMirrorConfig
 
         public Message CameraFov(int cameraFov) => WithArg($"{cameraFov}");
         public Message SetCustomCameraPosition(string posData) => WithArg($"{posData}");
+
         public Message EnableFreeCameraMode(bool enable) => WithArg($"{enable}");
         public Message ResetCameraPosition() => NoArg();
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -59,6 +59,17 @@
     <sys:String x:Key="Window_FetchUnityWindowPos">Check current window position</sys:String>
     <sys:String x:Key="Window_MoveWindow">Move to specified position</sys:String>
 
+    <sys:String x:Key="Window_TransparencySupport">Character Transparency Support</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level">Character Level</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Alpha">Alpha when Transparent(32-255)</sys:String>
+
+    <sys:String x:Key="Window_TransparencySupport_Level_0">Level 0: Always NOT transparent.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_1">Level 1: Transparent if "Drag character" is off, and mouse pointer is close to the character.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_2">Level 2: Transparent if mouse pointer is close to the character.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_3">Level 3: Transparent if "Drag character" is off.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_4">Level 4: Always transparent.</sys:String>
+    
+    
     <!-- Motion -->
     
     <!-- Motion : Face -->

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -58,6 +58,15 @@
     <sys:String x:Key="Window_FetchUnityWindowPos">いまのウィンドウ位置を記憶</sys:String>
     <sys:String x:Key="Window_MoveWindow">指定した位置へ移動</sys:String>
     
+    <sys:String x:Key="Window_TransparencySupport">キャラ透明化の詳細</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level">キャラの透明化レベル</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Alpha">透明になるときの透明度(32-255)</sys:String>
+    
+    <sys:String x:Key="Window_TransparencySupport_Level_0">レベル0: つねに不透明です。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_1">レベル1: 「キャラ付近を掴んでドラッグ」がオフで、かつキャラの近くにマウスポインタがあれば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_2">レベル2: キャラの近くにマウスポインタがあれば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_3">レベル3: 「キャラ付近を掴んでドラッグ」がオフならば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_4">レベル4: つねに半透明になります。</sys:String>
     
     <!-- Motion -->
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/VMagicMirrorConfig.csproj
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/VMagicMirrorConfig.csproj
@@ -125,6 +125,7 @@
     <Compile Include="View\AboutPanel.xaml.cs">
       <DependentUpon>AboutPanel.xaml</DependentUpon>
     </Compile>
+    <Compile Include="View\Code\IntegerEqualityToVisibilityConverter.cs" />
     <Compile Include="View\Code\TabHeaderIconText.xaml.cs">
       <DependentUpon>TabHeaderIconText.xaml</DependentUpon>
     </Compile>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/IntegerEqualityToVisibilityConverter.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/IntegerEqualityToVisibilityConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Baku.VMagicMirrorConfig
+{
+    public class IntegerEqualityToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is int i))
+            {
+                return Binding.DoNothing;
+            }
+
+            if (parameter is string s &&
+                int.TryParse(s, out int v1))
+            {
+                return (i == v1) ? Visibility.Visible : Visibility.Collapsed;
+            }
+            else if (parameter is int v2)
+            {
+                return (i == v2) ? Visibility.Visible : Visibility.Collapsed;
+            }
+            else
+            {
+                return Binding.DoNothing;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) 
+            => Binding.DoNothing;
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/WindowSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/WindowSettingPanel.xaml
@@ -6,6 +6,7 @@
              xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
              mc:Ignorable="d"
+             d:DesignWidth="400"
              d:DesignHeight="550"
              d:DataContext="{x:Type vmm:WindowSettingViewModel}"
              >
@@ -120,6 +121,94 @@
                     </Button>
                 </StackPanel>
             </md:Card>
+
+            <md:Card>
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+
+                        <md:PackIcon Kind="LayersClear"
+                                     Style="{StaticResource SettingHeaderPackIcon}"
+                                     />
+
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport}"
+                                   Margin="5"
+                                   Style="{StaticResource HeaderText}"
+                                   />
+                        
+                    </StackPanel>
+                    
+                    <TextBlock Margin="10" Text="{DynamicResource Window_TransparencySupport_Level}"/>
+
+                    <Slider Minimum="0" Maximum="4"
+                            Margin="15,0"
+                            Style="{StaticResource MaterialDesignDiscreteSlider}"
+                            Value="{Binding WholeWindowTransparencyLevel, Mode=TwoWay}"
+                            />
+
+                    <Grid Margin="20,10,20,20">
+                        <Grid.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="MinHeight" Value="40"/>
+                                <Setter Property="TextWrapping" Value="Wrap"/>
+                            </Style>
+                            <vmm:IntegerEqualityToVisibilityConverter x:Key="IntToVisibilityConverter"/>
+                        </Grid.Resources>
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport_Level_0}"
+                                   Visibility="{Binding WholeWindowTransparencyLevel, 
+                                                        Converter={StaticResource IntToVisibilityConverter},
+                                                        ConverterParameter=0
+                                                        }"
+                                   />
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport_Level_1}" 
+                                   Visibility="{Binding WholeWindowTransparencyLevel, 
+                                                        Converter={StaticResource IntToVisibilityConverter},
+                                                        ConverterParameter=1
+                                                        }"
+                                   />
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport_Level_2}" 
+                                   Visibility="{Binding WholeWindowTransparencyLevel, 
+                                                        Converter={StaticResource IntToVisibilityConverter},
+                                                        ConverterParameter=2
+                                                        }"
+                                   />
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport_Level_3}" 
+                                   Visibility="{Binding WholeWindowTransparencyLevel, 
+                                                        Converter={StaticResource IntToVisibilityConverter},
+                                                        ConverterParameter=3
+                                                        }"
+                                   />
+                        <TextBlock Text="{DynamicResource Window_TransparencySupport_Level_4}" 
+                                   Visibility="{Binding WholeWindowTransparencyLevel, 
+                                                        Converter={StaticResource IntToVisibilityConverter},
+                                                        ConverterParameter=4
+                                                        }"
+                                   />
+
+                    </Grid>
+
+                    <TextBlock Margin="10" 
+                               Text="{DynamicResource Window_TransparencySupport_Alpha}"
+                               />
+
+                    <Grid Margin="20,0,20,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Slider Grid.Column="0"                                
+                                x:Name="sliderAlphaWhenTransparent"
+                                Minimum="32" Maximum="255"
+                                Value="{Binding AlphaValueOnTransparent, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderAlphaWhenTransparent}"
+                                 />
+                    </Grid>
+
+                </StackPanel>
+            </md:Card>
+
 
             <!--<md:Card>
                 <StackPanel>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
@@ -141,6 +141,38 @@ namespace Baku.VMagicMirrorConfig
             SendMessage(MessageFactory.Instance.ResetWindowSize());
         }
 
+
+        private int _wholeWindowTransparencyLevel = 2;
+        public int WholeWindowTransparencyLevel
+        {
+            get => _wholeWindowTransparencyLevel;
+            set
+            {
+                if (SetValue(ref _wholeWindowTransparencyLevel, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.SetWholeWindowTransparencyLevel(_wholeWindowTransparencyLevel)
+                        );
+                }
+            }
+        }
+
+        private int _alphaValueOnTransparent = 128;
+        public int AlphaValueOnTransparent
+        {
+            get => _alphaValueOnTransparent;
+            set
+            {
+                if (SetValue(ref _alphaValueOnTransparent, value))
+                {
+                    SendMessage(
+                        MessageFactory.Instance.SetAlphaValueOnTransparent(_alphaValueOnTransparent)
+                        );
+                }
+            }
+        }
+
+
         #region privateになったプロパティ
 
         private bool _hideWindowFrame = false;
@@ -181,6 +213,9 @@ namespace Baku.VMagicMirrorConfig
             IsTransparent = false;
             WindowDraggable = true;
             TopMost = true;
+
+            WholeWindowTransparencyLevel = 2;
+            AlphaValueOnTransparent = 128;
 
             //このリセットはあまり定数的ではないことに注意！
             ResetWindowPosition();


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/pull/61

上記に対応するUIの更新。ウィンドウ設定部分に追加した。デフォルトの半透明レベルは2、つまりマウスがキャラ上に乗れば半透明にする。

半透明レベルについては説明必須に見えるため、説明用テキストはつねに表示する。
