### PR TITLE
Word to Motionのデフォルト設定の適用

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/MotionRequest.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/MotionRequest.cs
@@ -81,10 +81,72 @@ namespace Baku.VMagicMirrorConfig
                 MotionType = MotionTypeNone,
                 Word = "name",
                 UseBlendShape = true,
+                HoldBlendShape = false,
                 DurationWhenOnlyBlendShape = 3.0f,
             };
             result.BlendShapeValues["Joy"] = 100;
 
+            return result;
+        }
+
+        public static MotionRequest[] GetDefaultMotionRequestSet()
+        {
+            var result = new MotionRequest[]
+            {
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeNone,
+                    Word = "reset",
+                    UseBlendShape = true,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 0.1f,
+                },
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeNone,
+                    Word = "joy",
+                    UseBlendShape = true,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 3.0f,
+                },
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeNone,
+                    Word = "angry",
+                    UseBlendShape = true,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 3.0f,
+                },
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeNone,
+                    Word = "sorrow",
+                    UseBlendShape = true,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 3.0f,
+                },
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeNone,
+                    Word = "fun",
+                    UseBlendShape = true,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 3.0f,
+                },
+                new MotionRequest()
+                {
+                    MotionType = MotionTypeBuiltInClip,
+                    Word = "wave",
+                    BuiltInAnimationClipName = "Wave",
+                    UseBlendShape = false,
+                    HoldBlendShape = false,
+                    DurationWhenOnlyBlendShape = 3.0f,
+                },
+            };
+            result[1].BlendShapeValues["Joy"] = 100;
+            result[2].BlendShapeValues["Angry"] = 100;
+            result[3].BlendShapeValues["Sorrow"] = 100;
+            result[4].BlendShapeValues["Fun"] = 100;
             return result;
         }
     }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecialFileNames.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecialFileNames.cs
@@ -1,8 +1,0 @@
-﻿namespace Baku.VMagicMirrorConfig
-{
-    public static class SpecialFileNames
-    {
-        //拡張子.vmmを付けるのを期待したファイルだが、付けちゃうとユーザーの誤操作で上書きする懸念があるので、つけない。
-        public static readonly string AutoSaveSettingFileName = "_autosave";
-    }
-}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecialFilePath.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecialFilePath.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+using System.Reflection;
+
+namespace Baku.VMagicMirrorConfig
+{
+    public static class SpecialFilePath
+    {
+        //拡張子.vmmを付けるのを期待したファイルだが、付けちゃうとユーザーの誤操作で上書きする懸念があるので、つけない。
+        public static readonly string AutoSaveSettingFileName = "_autosave";
+
+        //実行中のVMagicMirrorの設定が保存された設定ファイルのパスを取得します。
+        public static string GetSettingFilePath()
+            => Path.Combine(
+            Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
+            AutoSaveSettingFileName
+            );
+
+        /// <summary>
+        /// <see cref="GetSettingFilePath"/>のパスに設定ファイルがあるかどうかを確認します。
+        /// </summary>
+        /// <returns></returns>
+        public static bool SettingFileExists() => File.Exists(GetSettingFilePath());
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/VMagicMirrorConfig.csproj
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/VMagicMirrorConfig.csproj
@@ -119,7 +119,7 @@
     <Compile Include="Model\InputObserver\WindowsApiDef.cs" />
     <Compile Include="Model\LanguageSelector.cs" />
     <Compile Include="Model\ModelInitializer.cs" />
-    <Compile Include="Model\SpecialFileNames.cs" />
+    <Compile Include="Model\SpecialFilePath.cs" />
     <Compile Include="Model\WindowPositionUtil.cs" />
     <Compile Include="Model\Messages.cs" />
     <Compile Include="Model\WordToMotionItemPreviewDataSender.cs" />

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -302,7 +302,7 @@ namespace Baku.VMagicMirrorConfig
                 string savePath = Path.Combine(
                     Path.GetDirectoryName(dialog.FileName),
                     "ConfigApp",
-                    "_autosave"
+                    SpecialFilePath.AutoSaveSettingFileName
                     );
 
                 LoadSetting(savePath, true);
@@ -339,7 +339,7 @@ namespace Baku.VMagicMirrorConfig
 
             Initializer.Initialize();
 
-            LoadSetting(GetFilePath(SpecialFileNames.AutoSaveSettingFileName), true);
+            LoadSetting(SpecialFilePath.GetSettingFilePath(), true);
 
             //LoadCurrentParametersの時点で(もし前回保存した)言語名があればLanguageNameに入っているので、それを渡す。
             LanguageSelector.Instance.Initialize(MessageSender, LanguageName);
@@ -373,7 +373,7 @@ namespace Baku.VMagicMirrorConfig
             if (!_isDisposed)
             {
                 _isDisposed = true;
-                SaveSetting(GetFilePath(SpecialFileNames.AutoSaveSettingFileName), true);
+                SaveSetting(SpecialFilePath.GetSettingFilePath(), true);
                 Initializer.Dispose();
                 MotionSetting.ClosePointer();
                 UnityAppCloser.Close();
@@ -475,7 +475,7 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
-        private string GetFilePath(string fileName)
+        private static string GetFilePath(string fileName)
             => Path.Combine(
                 Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
                 fileName

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
@@ -19,6 +19,8 @@ namespace Baku.VMagicMirrorConfig
             _previewDataSender = new WordToMotionItemPreviewDataSender(sender);
             _previewDataSender.PrepareDataSend += 
                 (_, __) => _dialogItem?.WriteToModel(_previewDataSender.MotionRequest);
+
+            LoadDefaultItemsIfInitialStart();
         }
 
         private readonly WordToMotionItemPreviewDataSender _previewDataSender;
@@ -177,8 +179,27 @@ namespace Baku.VMagicMirrorConfig
 
         public override void ResetToDefault()
         {
-            //とりあえず無視！
-            //本来はアイテム一覧を喜怒哀楽セットにするくらいがちょうどいいか
+            //何もしない: ここは設定がフクザツなのでとりあえずいじらない方針で。
+            //(このパネル単体のリセットUIがちゃんとできたら何か考える)
+            //->autosaveが無い状態で
+        }
+
+        //このマシン上でこのバージョンのVMagicMirrorが初めて実行された可能性が高いとき、
+        //デフォルトのWord To Motion一覧を生成して初期化します。
+        public void LoadDefaultItemsIfInitialStart()
+        {
+            if (SpecialFilePath.SettingFileExists()) 
+            {
+                return;
+            }
+
+            _items.Clear();
+            var models = MotionRequest.GetDefaultMotionRequestSet();
+            for (int i = 0; i < models.Length; i++)
+            {
+                _items.Add(new WordToMotionItemViewModel(this, models[i]));
+            }
+            RequestReload();
         }
 
         public void EditItemByDialog(WordToMotionItemViewModel item)


### PR DESCRIPTION
初回起動かどうかを"_autosave"ファイルの有無で判定し、初回起動であればWord to Motionに基本セットとなるWord to Motionアイテムを適用する。

なお、設定リセット処理はWord to Motionについては対象外としている(他に巻き込まれて初期化すると不便そうなため)。