### PR TITLE
カテゴリ別のリセットボタンを復活

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/App.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/App.xaml
@@ -59,7 +59,6 @@
             </Style>
 
             <Style TargetType="{x:Type md:Card}" BasedOn="{StaticResource {x:Type md:Card}}">
-                <!--<Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}"/>-->
                 <Setter Property="md:ShadowAssist.ShadowDepth" Value="Depth1"/>
                 <Setter Property="Margin" Value="10,5"/>
                 <Setter Property="Padding" Value="10"/>
@@ -69,10 +68,28 @@
                 <!--<Setter Property="Background" Value="White"/>-->
                 <Setter Property="Width" Value="25"/>
                 <Setter Property="Height" Value="25"/>
-                <Setter Property="Margin" Value="20,0"/>
+                <Setter Property="Margin" Value="20,0,5,0"/>
                 <Setter Property="Padding" Value="0"/>
             </Style>
 
+            <Style x:Key="CategorySettingResetButton"
+                   x:Shared="False"
+                   TargetType="Button" 
+                   BasedOn="{StaticResource MaterialDesignFlatButton}">
+                <Setter Property="Width" Value="25"/>
+                <Setter Property="Height" Value="25"/>
+                <Setter Property="Margin" Value="5,0"/>
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="VerticalAlignment" Value="Bottom"/>
+                <Setter Property="Content">
+                    <Setter.Value>
+                        <md:PackIcon Kind="Refresh" 
+                                     Foreground="{StaticResource PrimaryHueMidBrush}"
+                                     />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+                       
             <Style TargetType="{x:Type Expander}" BasedOn="{StaticResource MaterialDesignExpander}"/>
 
             <!-- Dragablz Material Design -->

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageIndication.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/MessageIndication.cs
@@ -19,6 +19,9 @@
         public static MessageIndication ResetSettingConfirmation(string languageName)
             => ResetSettingConfirmation(LanguageSelector.StringToLanguage(languageName));
 
+        public static MessageIndication ResetSingleCategoryConfirmation(string languageName)
+            => ResetSingleCategoryConfirmation(LanguageSelector.StringToLanguage(languageName));
+
         public static MessageIndication ErrorLoadSetting(string languageName)
             => ErrorLoadSetting(LanguageSelector.StringToLanguage(languageName));
 
@@ -64,6 +67,24 @@
                     return new MessageIndication(
                         "Reset Setting",
                         "Are you sure you want to reset all settings in VMagicMirror?"
+                        );
+            }
+        }
+
+        public static MessageIndication ResetSingleCategoryConfirmation(Languages lang)
+        {
+            switch (lang)
+            {
+                case Languages.Japanese:
+                    return new MessageIndication(
+                        "設定のリセット",
+                        "選択したカテゴリの設定をリセットしますか？"
+                        );
+                case Languages.English:
+                default:
+                    return new MessageIndication(
+                        "Reset Setting",
+                        "Are you sure you want to reset selected category setting?"
                         );
             }
         }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -200,6 +200,7 @@
     <sys:String x:Key="WordToMotion_Instruction" xml:space="preserve">This tab is `Word to Motion` tab.
 `Word to Motion` feature supports character motion by your word input.
 Please test by typing "joy".</sys:String>
+    <sys:String x:Key="WordToMotion_LoadDefaultSet">Reset to default items</sys:String>
 
     <sys:String x:Key="WordToMotion_Word_Header">Word</sys:String>
     <sys:String x:Key="WordToMotion_Word_Limit">*Lower alphabet, number, and space</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -195,7 +195,8 @@
     <sys:String x:Key="WordToMotion_Instruction" xml:space="preserve">このタブは `Word to Motion` タブです。
 `Word to Motion`は、単語をタイピングするとキャラクターを動かせる機能です。
 ためしに "joy" とタイピングしてみてください。</sys:String>
-
+    <sys:String x:Key="WordToMotion_LoadDefaultSet">デフォルト設定にリセット</sys:String>
+    
     <sys:String x:Key="WordToMotion_Word_Header">Word</sys:String>
     <sys:String x:Key="WordToMotion_Word_Limit">*半角アルファベット、数字、スペースのみ</sys:String>
 
@@ -214,6 +215,5 @@
     <sys:String x:Key="WordToMotion_Face_Hold">アニメーション終了後も表情を維持</sys:String>
     
     <sys:String x:Key="WordToMotion_EnablePreview">現在のキャラクターでプレビュー</sys:String>    
-    
-    
+        
 </ResourceDictionary>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/WhiteSpaceStringToNullConverter.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/WhiteSpaceStringToNullConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Baku.VMagicMirrorConfig
+{
+    public class WhiteSpaceStringToNullConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string s)
+            {
+                //""をnullに変換するのがポイント:
+                return string.IsNullOrEmpty(s) ? null : s;
+            }
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (value is string s) ? s : Binding.DoNothing;
+        }
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LayoutSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LayoutSettingPanel.xaml
@@ -35,6 +35,10 @@
                                    VerticalAlignment="Center"
                                    Margin="5"
                                    />
+                        <!-- このリセットボタンは他と違って「位置をリセット」と同じ処理で、確認ダイアログは出ない -->
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetCameraPositionCommand}"
+                                />
                     </StackPanel>
                     
 
@@ -42,10 +46,6 @@
                               IsChecked="{Binding EnableFreeCameraMode}"
                               Margin="10,5"
                               />
-                    <TextBlock Text="{DynamicResource Layout_CurrentCameraPosition}"/>
-                    <TextBlock Text="{Binding CameraPosition}"
-                               Margin="15,5"
-                               />
 
                     <Grid Margin="5">
                         <Grid.ColumnDefinitions>
@@ -100,6 +100,10 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetHidSettingCommand}"
+                                />
                     </StackPanel>
 
                     <Grid Margin="5">
@@ -204,6 +208,9 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding Gamepad.ResetSettingCommand}"
+                                />
                     </StackPanel>
                     
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LightSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LightSettingPanel.xaml
@@ -41,6 +41,10 @@
                                 </Rectangle.Fill>
                             </Rectangle>
                         </md:Card>
+                        
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetLightSettingCommand}"
+                                />
 
                     </StackPanel>
 
@@ -149,6 +153,10 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetShadowSettingCommand}"
+                                />
                     </StackPanel>
 
                     <CheckBox Margin="10,5,10,15"
@@ -250,6 +258,9 @@
                             </Rectangle>
                         </md:Card>
 
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetBloomSettingCommand}"
+                                />
                     </StackPanel>
 
                     <Grid Margin="5">

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/MotionSettingPanel.xaml
@@ -10,6 +10,9 @@
              d:DesignWidth="400"
              d:DesignHeight="1050"
              >
+    <UserControl.Resources>
+        <vmm:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
+    </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   >
@@ -67,7 +70,7 @@
                                   Width="200"
                                   IsEnabled="{Binding EnableLipSync}"
                                   ItemsSource="{Binding MicrophoneDeviceNames}"
-                                  SelectedItem="{Binding LipSyncMicrophoneDeviceName}"
+                                  SelectedItem="{Binding LipSyncMicrophoneDeviceName, Converter={StaticResource WhiteSpaceStringToNullConverter}}"
                                   md:HintAssist.Hint="Microphone"
                                   />
 
@@ -95,7 +98,7 @@
                                   Width="200"
                                   IsEnabled="{Binding EnableFaceTracking}"
                                   ItemsSource="{Binding CameraDeviceNames}"
-                                  SelectedItem="{Binding CameraDeviceName}"
+                                  SelectedItem="{Binding CameraDeviceName, Converter={StaticResource WhiteSpaceStringToNullConverter}}"
                                   md:HintAssist.Hint="Camera"
                                   />
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/MotionSettingPanel.xaml
@@ -27,6 +27,9 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetFaceMotionSettingCommand}"
+                                />
                     </StackPanel>
 
                     <Grid Margin="5">
@@ -296,6 +299,10 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetArmMotionSettingCommand}"
+                                />
                     </StackPanel>
 
                     <CheckBox Margin="15,5,15,10" 
@@ -404,6 +411,9 @@
                                    Margin="5"
                                    Style="{StaticResource HeaderText}"
                                    />
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetHandMotionSettingCommand}"
+                                />
                     </StackPanel>
                     
                     <Grid Margin="5,0,0,10">
@@ -483,6 +493,11 @@
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
+                    
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetWaitMotionSettingCommand}"
+                                />
+
                     </StackPanel>
 
                     <Grid Margin="5,0,0,10">

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/StreamingPanel.xaml
@@ -11,6 +11,7 @@
              d:DesignHeight="410"
              >
     <UserControl.Resources>
+        <vmm:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
         <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
             <Setter Property="Margin" Value="5"/>
         </Style>
@@ -112,7 +113,7 @@
                                           Margin="5,0"
                                           IsEnabled="{Binding MotionSetting.EnableLipSync}"
                                           ItemsSource="{Binding MotionSetting.MicrophoneDeviceNames}"
-                                          SelectedItem="{Binding MotionSetting.LipSyncMicrophoneDeviceName}"
+                                          SelectedItem="{Binding MotionSetting.LipSyncMicrophoneDeviceName, Converter={StaticResource WhiteSpaceStringToNullConverter}}"
                                           md:HintAssist.Hint="Microphone"
                                           />
 
@@ -138,7 +139,7 @@
                                           Margin="5,0"
                                           IsEnabled="{Binding MotionSetting.EnableFaceTracking}"
                                           ItemsSource="{Binding MotionSetting.CameraDeviceNames}"
-                                          SelectedItem="{Binding MotionSetting.CameraDeviceName}"
+                                          SelectedItem="{Binding MotionSetting.CameraDeviceName, Converter={StaticResource WhiteSpaceStringToNullConverter}}"
                                           md:HintAssist.Hint="Camera"
                                           />
                             </Grid>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/WindowSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/WindowSettingPanel.xaml
@@ -7,7 +7,7 @@
              xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
              mc:Ignorable="d"
              d:DesignWidth="400"
-             d:DesignHeight="550"
+             d:DesignHeight="650"
              d:DataContext="{x:Type vmm:WindowSettingViewModel}"
              >
     <UserControl.Resources>
@@ -41,6 +41,10 @@
                                 </Rectangle.Fill>
                             </Rectangle>
                         </md:Card>
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetBackgroundColorSettingCommand}"
+                                />
                     </StackPanel>
 
                     <Grid>
@@ -134,7 +138,10 @@
                                    Margin="5"
                                    Style="{StaticResource HeaderText}"
                                    />
-                        
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetOpacitySettingCommand}"
+                                />
                     </StackPanel>
                     
                     <TextBlock Margin="10" Text="{DynamicResource Window_TransparencySupport_Level}"/>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/WordToMotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/WordToMotionSettingPanel.xaml
@@ -31,13 +31,13 @@
                    />
 
         <CheckBox Grid.Row="1"
-                  Margin="5,0"
+                  Margin="15,0"
                   Content="{DynamicResource WordToMotion_Enable}"
                   IsChecked="{Binding EnableWordToMotion}"
                   />
 
         <CheckBox Grid.Row="2"
-                  Margin="15,5"
+                  Margin="25,5"
                   Content="{DynamicResource WordToMotion_UseGamepadForInput}"
                   IsEnabled="{Binding EnableWordToMotion}"
                   IsChecked="{Binding UseGamepadToStartWordToMotion}"
@@ -223,13 +223,23 @@
                 <Button Grid.Column="1" 
                         IsEnabled="{Binding EnableWordToMotion}"
                         Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
-                        HorizontalAlignment="Right"
+                        HorizontalAlignment="Left"
                         VerticalAlignment="Bottom"
                         Margin="15"
                         Command="{Binding AddNewItemCommand}"
                         >
                     <md:PackIcon Kind="Plus" Width="26" Height="26"/>
                 </Button>
+
+                <Button Grid.Column="1" 
+                        IsEnabled="{Binding EnableWordToMotion}"
+                        Style="{StaticResource MaterialDesignFlatButton}"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="15"
+                        Command="{Binding ResetByDefaultItemsCommand}"
+                        Content="{DynamicResource WordToMotion_LoadDefaultSet}"
+                        />
 
             </Grid>
         </ScrollViewer>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
@@ -208,6 +208,13 @@ namespace Baku.VMagicMirrorConfig
 
         #endregion
 
+        private ActionCommand _resetSettingCommand = null;
+        public ActionCommand ResetSettingCommand
+            => _resetSettingCommand ??
+            (_resetSettingCommand = new ActionCommand(ResetCommandImpl));
+        private void ResetCommandImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetToDefault);
+
         public override void ResetToDefault()
         {
             GamepadEnabled = true;

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LayoutSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LayoutSettingViewModel.cs
@@ -245,18 +245,35 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
-        public override void ResetToDefault()
-        {
-            Gamepad.ResetToDefault();
+        #region Reset API
 
+        private ActionCommand _resetHidSettingCommand = null;
+        public ActionCommand ResetHidSettingCommand
+            => _resetHidSettingCommand ??
+            (_resetHidSettingCommand = new ActionCommand(ResetHidCommandImpl));
+        private void ResetHidCommandImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetHidSetting);
+        
+        private void ResetHidSetting()
+        {
             HidHeight = 90;
             HidHorizontalScale = 70;
             HidVisibility = true;
             CameraFov = 40;
             TypingEffectIsNone = true;
+        }
+
+
+        public override void ResetToDefault()
+        {
+            Gamepad.ResetToDefault();
+ 
+            ResetHidSetting();
 
             //カメラ位置については、Unity側がカメラの基準位置を持っているのに任せる
             ResetCameraPosition();
         }
+
+        #endregion
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
@@ -285,7 +285,28 @@ namespace Baku.VMagicMirrorConfig
 
         #endregion
 
-        public override void ResetToDefault()
+        #region Reset API
+
+        private ActionCommand _resetLightSettingCommand = null;
+        public ActionCommand ResetLightSettingCommand
+            => _resetLightSettingCommand ?? (_resetLightSettingCommand = new ActionCommand(ResetLightImpl));
+        private void ResetLightImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetLightSetting);
+
+        private ActionCommand _resetShadowSettingCommand = null;
+        public ActionCommand ResetShadowSettingCommand
+            => _resetShadowSettingCommand ?? (_resetShadowSettingCommand = new ActionCommand(ResetShadowImpl));
+        private void ResetShadowImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetShadowSetting);
+
+        private ActionCommand _resetBloomSettingCommand = null;
+        public ActionCommand ResetBloomSettingCommand
+            => _resetBloomSettingCommand ?? (_resetBloomSettingCommand = new ActionCommand(ResetBloomImpl));
+        private void ResetBloomImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetBloomSetting);
+
+
+        private void ResetLightSetting()
         {
             LightR = 255;
             LightG = 244;
@@ -293,17 +314,34 @@ namespace Baku.VMagicMirrorConfig
             LightIntensity = 100;
             LightYaw = -30;
             LightPitch = 50;
+        }
 
+        private void ResetShadowSetting()
+        {
             EnableShadow = true;
             ShadowIntensity = 65;
             ShadowYaw = -20;
             ShadowPitch = 8;
+            ShadowDepthOffset = 40;
+        }
 
+        private void ResetBloomSetting()
+        {
             BloomR = 255;
             BloomG = 255;
             BloomB = 255;
             BloomIntensity = 50;
             BloomThreshold = 100;
         }
+
+
+        public override void ResetToDefault()
+        {
+            ResetLightSetting();
+            ResetShadowSetting();
+            ResetBloomSetting();
+        }
+
+        #endregion
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -17,7 +17,7 @@ namespace Baku.VMagicMirrorConfig
 
         private LargePointerController _largePointerController => LargePointerController.Instance;
 
-        //フラグが立っている間はプロパティが変わってもメッセージを投げない。これはUnityから指定されたパラメタの適用中に
+        //フラグが立っている間はプロパティが変わってもメッセージを投げない。これはUnityから指定されたパラメタの適用中に立てる
         private bool _silentPropertySetter = false;
         private protected override void SendMessage(Message message)
         {
@@ -609,7 +609,37 @@ namespace Baku.VMagicMirrorConfig
 
         #endregion
 
-        public override void ResetToDefault()
+        #region Reset API
+
+        private ActionCommand _resetFaceMotionSettingCommand = null;
+        public ActionCommand ResetFaceMotionSettingCommand
+            => _resetFaceMotionSettingCommand ?? 
+            (_resetFaceMotionSettingCommand = new ActionCommand(ResetFaceMotionCommandImpl));
+        private void ResetFaceMotionCommandImpl() 
+            => SettingResetUtils.ResetSingleCategorySetting(ResetFaceSetting);
+
+        private ActionCommand _resetArmMotionSettingCommand = null;
+        public ActionCommand ResetArmMotionSettingCommand
+            => _resetArmMotionSettingCommand ??
+            (_resetArmMotionSettingCommand = new ActionCommand(ResetArmMotionSettingImpl));
+        private void ResetArmMotionSettingImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetArmSetting);
+
+        private ActionCommand _resetHandMotionSettingCommand = null;
+        public ActionCommand ResetHandMotionSettingCommand
+            => _resetHandMotionSettingCommand ??
+            (_resetHandMotionSettingCommand = new ActionCommand(ResetHandMotionSettingImpl));
+        private void ResetHandMotionSettingImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetHandSetting);
+
+        private ActionCommand _resetWaitMotionSettingCommand = null;
+        public ActionCommand ResetWaitMotionSettingCommand
+            => _resetWaitMotionSettingCommand ?? 
+            (_resetWaitMotionSettingCommand = new ActionCommand(ResetWaitMotionSettingImpl));
+        private void ResetWaitMotionSettingImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetWaitMotionSetting);
+
+        private void ResetFaceSetting()
         {
             EnableFaceTracking = true;
             CameraDeviceName = "";
@@ -624,29 +654,48 @@ namespace Baku.VMagicMirrorConfig
 
             FaceDefaultFun = 20;
 
-            EyebrowLeftUpKey = ""; 
+            EyebrowLeftUpKey = "";
             EyebrowLeftDownKey = "";
             UseSeparatedKeyForEyebrow = false;
             EyebrowRightUpKey = "";
             EyebrowRightDownKey = "";
             EyebrowUpScale = 100;
             EyebrowDownScale = 100;
+        }
 
+        private void ResetArmSetting()
+        {
             EnableHidArmMotion = true;
             WaistWidth = 30;
             ElbowCloseStrength = 30;
             EnablePresenterMotion = false;
             PresentationArmMotionScale = 30;
             PresentationArmRadiusMin = 20;
+        }
 
+        private void ResetHandSetting()
+        {
             LengthFromWristToTip = 12;
             LengthFromWristToPalm = 6;
             HandYOffsetBasic = 3;
             HandYOffsetAfterKeyDown = 2;
+        }
 
+        private void ResetWaitMotionSetting()
+        {
             EnableWaitMotion = true;
             WaitMotionScale = 125;
             WaitMotionPeriod = 10;
         }
+
+        public override void ResetToDefault()
+        {
+            ResetFaceSetting();
+            ResetArmSetting();
+            ResetHandSetting();
+            ResetWaitMotionSetting();
+        }
+
+        #endregion
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/SettingResetUtils.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/SettingResetUtils.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Windows;
+
+namespace Baku.VMagicMirrorConfig
+{
+    /// <summary>
+    /// 設定リセット処理の共通処理
+    /// </summary>
+    static class SettingResetUtils
+    {
+        /// <summary>
+        /// 確認ダイアログを出したうえで、個別カテゴリの設定をリセットします。
+        /// </summary>
+        /// <param name="resetAction"></param>
+        public static void ResetSingleCategorySetting(Action resetAction)
+        {
+            var indication = MessageIndication.ResetSingleCategoryConfirmation(
+                LanguageSelector.Instance.LanguageName
+                );
+
+            MessageBoxResult res;
+            if (SettingWindow.CurrentWindow != null)
+            {
+                res = MessageBox.Show(
+                    SettingWindow.CurrentWindow,    
+                    indication.Content,
+                    indication.Title,
+                    MessageBoxButton.OKCancel
+                    );
+            }
+            else
+            {
+                res = MessageBox.Show(
+                    indication.Content,
+                    indication.Title,
+                    MessageBoxButton.OKCancel
+                    );
+            }
+
+            if (res == MessageBoxResult.OK)
+            {
+                resetAction();
+            }
+        }
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 using System.Xml.Serialization;
 
 namespace Baku.VMagicMirrorConfig
@@ -209,17 +206,47 @@ namespace Baku.VMagicMirrorConfig
 
         #endregion
 
-        public override void ResetToDefault()
+        #region Reset API
+
+        private ActionCommand _resetBackgroundColorSettingCommand = null;
+        public ActionCommand ResetBackgroundColorSettingCommand
+            => _resetBackgroundColorSettingCommand ??
+            (_resetBackgroundColorSettingCommand = new ActionCommand(ResetBackgroundColorSettingImpl));
+        private void ResetBackgroundColorSettingImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetBackgroundColor);
+
+        private void ResetBackgroundColor()
         {
             R = 0;
             G = 255;
             B = 0;
+        }
+
+        private ActionCommand _resetOpacitySettingCommand = null;
+        public ActionCommand ResetOpacitySettingCommand
+            => _resetOpacitySettingCommand ??
+            (_resetOpacitySettingCommand = new ActionCommand(ResetOpacitySettingImpl));
+        private void ResetOpacitySettingImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(ResetOpacity);
+
+        private void ResetOpacity()
+        {
+            WholeWindowTransparencyLevel = 2;
+            AlphaValueOnTransparent = 128;
+        }
+
+
+        #endregion
+
+        public override void ResetToDefault()
+        {
+            ResetBackgroundColor();
+
             IsTransparent = false;
             WindowDraggable = true;
             TopMost = true;
 
-            WholeWindowTransparencyLevel = 2;
-            AlphaValueOnTransparent = 128;
+            ResetOpacity();
 
             //このリセットはあまり定数的ではないことに注意！
             ResetWindowPosition();

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
@@ -200,14 +200,19 @@ namespace Baku.VMagicMirrorConfig
             SendMessage(MessageFactory.Instance.ReloadMotionRequests(ItemsContentString));
         }
 
+        private ActionCommand _resetByDefaultItemsCommand = null;
+        public ActionCommand ResetByDefaultItemsCommand
+            => _resetByDefaultItemsCommand ?? (_resetByDefaultItemsCommand = new ActionCommand(ResetByDefaultItemsImpl));
+        private void ResetByDefaultItemsImpl()
+            => SettingResetUtils.ResetSingleCategorySetting(LoadDefaultItems);
+
         public override void ResetToDefault()
         {
             //何もしない: ここは設定がフクザツなのでとりあえずいじらない方針で。
             //(このパネル単体のリセットUIがちゃんとできたら何か考える)
-            //->autosaveが無い状態で
         }
 
-        //このマシン上でこのバージョンのVMagicMirrorが初めて実行された可能性が高いとき、
+        //このマシン上でこのバージョンのVMagicMirrorが初めて実行されたと推定できるとき、
         //デフォルトのWord To Motion一覧を生成して初期化します。
         public void LoadDefaultItemsIfInitialStart()
         {
@@ -215,7 +220,11 @@ namespace Baku.VMagicMirrorConfig
             {
                 return;
             }
+            LoadDefaultItems();
+        }
 
+        private void LoadDefaultItems()
+        {
             _items.Clear();
             var models = MotionRequest.GetDefaultMotionRequestSet();
             for (int i = 0; i < models.Length; i++)


### PR DESCRIPTION
## 概要

https://github.com/malaybaku/VMagicMirror/issues/125

## 補足

* 表情のリセットをすると眉毛の設定も一旦吹っ飛ぶことに注意。
    * これはVRoidの自動調整対象になっているモデルの場合、VMMを再起動すると元に戻る。
* バグfixで、v0.9.1では設定リセット時にカメラ/マイクの選択が空白に戻らない不具合があったのを直した。
    * このバグは地味に厄介で、1つしかマイク/カメラが刺さってない環境の場合、設定ファイル(_autosave)削除でしか復帰できないバグだった。