### PR TITLE
Feature/v0.9.5

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Common/SettingResetUtils.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Common/SettingResetUtils.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Windows;
 
 namespace Baku.VMagicMirrorConfig
 {
@@ -12,32 +11,19 @@ namespace Baku.VMagicMirrorConfig
         /// 確認ダイアログを出したうえで、個別カテゴリの設定をリセットします。
         /// </summary>
         /// <param name="resetAction"></param>
-        public static void ResetSingleCategorySetting(Action resetAction)
+        public static async void ResetSingleCategorySettingAsync(Action resetAction)
         {
             var indication = MessageIndication.ResetSingleCategoryConfirmation(
                 LanguageSelector.Instance.LanguageName
                 );
 
-            MessageBoxResult res;
-            if (SettingWindow.CurrentWindow != null)
-            {
-                res = MessageBox.Show(
-                    SettingWindow.CurrentWindow,    
-                    indication.Content,
-                    indication.Title,
-                    MessageBoxButton.OKCancel
-                    );
-            }
-            else
-            {
-                res = MessageBox.Show(
-                    indication.Content,
-                    indication.Title,
-                    MessageBoxButton.OKCancel
-                    );
-            }
+            bool res = await MessageBoxWrapper.Instance.ShowAsync(
+                indication.Title, 
+                indication.Content,
+                MessageBoxWrapper.MessageBoxStyle.OKCancel
+                );
 
-            if (res == MessageBoxResult.OK)
+            if (res)
             {
                 resetAction();
             }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig
+{
+    class MessageBoxWrapper
+    {
+        private MessageBoxWrapper() { }
+        private static MessageBoxWrapper? _instance;
+        public static MessageBoxWrapper Instance
+            => _instance ??= new MessageBoxWrapper();
+
+        private readonly Queue<TaskCompletionSource<bool>> _dialogTasks = new Queue<TaskCompletionSource<bool>>();
+
+        /// <summary>
+        /// メインウィンドウ、および表示されている場合は設定ウィンドウに、
+        /// 同時にダイアログを表示します。
+        /// 片方のダイアログを閉じた時点でもう片方を閉じて結果を返します。
+        /// MessageBox.Showの代わりに呼び出して使います。
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> ShowAsync(string title, string content, MessageBoxStyle style)
+        {
+            DialogHelperViewModel.Instance.Title = title;
+            DialogHelperViewModel.Instance.Content = content;
+            DialogHelperViewModel.Instance.CanCancel = (style == MessageBoxStyle.OKCancel);
+            DialogHelperViewModel.Instance.IsOpen = true;
+
+            var result = new TaskCompletionSource<bool>();
+            _dialogTasks.Enqueue(result);
+            return result.Task;            
+        }
+
+        /// <summary>
+        /// ダイアログの結果を設定します。DialogHelperViewModelから呼び出します。
+        /// </summary>
+        /// <param name="result"></param>
+        public void SetDialogResult(bool result)
+        {
+            if (_dialogTasks.Count > 0)
+            {
+                var tcs = _dialogTasks.Dequeue();
+                tcs.SetResult(result);
+            }
+        }
+
+        public enum MessageBoxStyle
+        {
+            OK,
+            OKCancel,
+        }
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/AboutPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/AboutPanel.xaml
@@ -15,7 +15,7 @@
     <StackPanel HorizontalAlignment="Left"
                 Margin="10">
         <TextBlock Style="{StaticResource NoteText}"
-                        Text="VMagicMirror v0.9.4"/>
+                        Text="VMagicMirror v0.9.5"/>
         <TextBlock Style="{StaticResource NoteText}"
                         Text="Copyright (c) 2019 獏星(ばくすたー)"/>
         <TextBlock Style="{StaticResource NoteText}"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/LayoutSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/LayoutSettingPanel.xaml
@@ -276,7 +276,7 @@
 
                         <CheckBox Margin="20,2"
                               VerticalContentAlignment="Center"
-                              IsChecked="{Binding GamepadVisibility}">
+                              IsChecked="{Binding Gamepad.GamepadVisibility}">
                             <TextBlock Text="{DynamicResource Layout_GamepadVisible}"/>
                         </CheckBox>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
@@ -16,35 +16,66 @@
     <Window.DataContext>
         <vmm:MainWindowViewModel/>
     </Window.DataContext>
-    <dragablz:TabablzControl FixedHeaderCount="5">
-        <dragablz:TabablzControl.HeaderItemTemplate>
-            <DataTemplate>
-                <ContentControl Content="{Binding}"/>
-            </DataTemplate>
-        </dragablz:TabablzControl.HeaderItemTemplate>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Home}"
-                                       IconKind="Home"
-                                       />
-            </TabItem.Header>
-            <vmm:HomePanel />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Streaming}"
-                                       IconKind="Videocam"
-                                       />
-            </TabItem.Header>
-            <vmm:StreamingPanel />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="About"
-                                       IconKind="HelpOutline"
-                                       />
-            </TabItem.Header>
-            <vmm:AboutPanel />
-        </TabItem>
-    </dragablz:TabablzControl>
+    <md:DialogHost IsOpen="{Binding DialogHelper.IsOpen}">
+        <md:DialogHost.DialogContent>
+            <StackPanel Orientation="Vertical"
+                        VerticalAlignment="Center">
+                <TextBlock Text="{Binding DialogHelper.Title}"
+                           Margin="10"
+                           TextAlignment="Center"
+                           Foreground="Black"
+                           FontWeight="Bold"
+                           />
+                <TextBlock Text="{Binding DialogHelper.Content}"
+                           Margin="10,0,10,20"
+                           TextAlignment="Center"
+                           Foreground="Black"
+                           />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Content="OK"
+                            Command="{Binding DialogHelper.OKCommand}"
+                            />
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Visibility="{Binding DialogHelper.CanCancel, 
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Content="Cancel"
+                            Command="{Binding DialogHelper.CancelCommand}"
+                            />
+                </StackPanel>
+            </StackPanel>
+        </md:DialogHost.DialogContent>
+
+        <dragablz:TabablzControl FixedHeaderCount="5">
+            <dragablz:TabablzControl.HeaderItemTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding}"/>
+                </DataTemplate>
+            </dragablz:TabablzControl.HeaderItemTemplate>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Home}"
+                                           IconKind="Home"
+                                           />
+                </TabItem.Header>
+                <vmm:HomePanel />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Streaming}"
+                                           IconKind="Videocam"
+                                           />
+                </TabItem.Header>
+                <vmm:StreamingPanel />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="About"
+                                           IconKind="HelpOutline"
+                                           />
+                </TabItem.Header>
+                <vmm:AboutPanel />
+            </TabItem>
+        </dragablz:TabablzControl>
+    </md:DialogHost>
 </Window>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
         mc:Ignorable="d"
         d:DataContext="{x:Type vmm:MainWindowViewModel}"
-        Title="VMagicMirror v0.9.4" 
+        Title="VMagicMirror v0.9.5" 
         ResizeMode="CanMinimize"
         Height="600" Width="550"
         MinHeight="600" MinWidth="550"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows;
 
 namespace Baku.VMagicMirrorConfig

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
@@ -12,71 +12,102 @@
         Height="660" Width="500"
         MinHeight="200" MinWidth="430"
         >
-    <dragablz:TabablzControl FixedHeaderCount="5">
-        <dragablz:TabablzControl.HeaderItemTemplate>
-            <DataTemplate>
-                <ContentControl Content="{Binding}"/>
-            </DataTemplate>
-        </dragablz:TabablzControl.HeaderItemTemplate>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Window}"
-                                       IconKind="WindowRestore"
-                                       />
-            </TabItem.Header>
-            <vmm:WindowSettingPanel DataContext="{Binding WindowSetting}" />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Motion}"
-                                       IconKind="HumanHandsup"
-                                       />
-            </TabItem.Header>
-            <vmm:MotionSettingPanel DataContext="{Binding MotionSetting}" />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Layout}"
-                                       IconKind="ViewDashboard"
-                                       />
-            </TabItem.Header>
-            <vmm:LayoutSettingPanel DataContext="{Binding LayoutSetting}" />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Effects}"
-                                       IconKind="Lightbulb"
-                                       />
-            </TabItem.Header>
-            <vmm:LightSettingPanel DataContext="{Binding LightSetting}" />
-        </TabItem>
-        <TabItem>
-            <TabItem.Header>
-                <!-- NOTE: "Word to Motion"が正式名だが、長すぎるのでアイコンにしておく-->
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                    </Grid.ColumnDefinitions>
-                    <md:PackIcon Grid.Column="0"
-                                 Width="23" Height="23"
-                                 VerticalAlignment="Center"
-                                 Kind="ABC"/>
-                    <md:PackIcon Grid.Column="1"
-                                 Width="16" Height="16"
-                                 Margin="2,0,0,0"
-                                 VerticalAlignment="Center"                                 
-                                 Kind="ArrowRightBold"/>
-                    <md:PackIcon Grid.Column="2"
-                                 Width="20" Height="20"
-                                 Margin="-2,1,0,0"
-                                 VerticalAlignment="Center"
-                                 Kind="HumanHandsup">
-                    </md:PackIcon>
-                </Grid>
-            </TabItem.Header>
-            <vmm:WordToMotionSettingPanel DataContext="{Binding WordToMotionSetting}" />
-        </TabItem>
-    </dragablz:TabablzControl>
+    <md:DialogHost IsOpen="{Binding DialogHelper.IsOpen}">
+        <md:DialogHost.DialogContent>
+            <StackPanel Orientation="Vertical"
+                        VerticalAlignment="Center">
+                <TextBlock Text="{Binding DialogHelper.Title}"
+                           Margin="10"
+                           TextAlignment="Center"
+                           Foreground="Black"
+                           FontWeight="Bold"
+                           />
+                <TextBlock Text="{Binding DialogHelper.Content}"
+                           Margin="10,0,10,20"
+                           TextAlignment="Center"
+                           Foreground="Black"
+                           />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Content="OK"
+                            Command="{Binding DialogHelper.OKCommand}"
+                            />
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Visibility="{Binding DialogHelper.CanCancel, 
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Content="Cancel"
+                            Command="{Binding DialogHelper.CancelCommand}"
+                            />
+                </StackPanel>
+            </StackPanel>
+        </md:DialogHost.DialogContent>
+
+        <dragablz:TabablzControl FixedHeaderCount="5">
+            <dragablz:TabablzControl.HeaderItemTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding}"/>
+                </DataTemplate>
+            </dragablz:TabablzControl.HeaderItemTemplate>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Window}"
+                                           IconKind="WindowRestore"
+                                           />
+                </TabItem.Header>
+                <vmm:WindowSettingPanel DataContext="{Binding WindowSetting}" />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Motion}"
+                                           IconKind="HumanHandsup"
+                                           />
+                </TabItem.Header>
+                <vmm:MotionSettingPanel DataContext="{Binding MotionSetting}" />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Layout}"
+                                           IconKind="ViewDashboard"
+                                           />
+                </TabItem.Header>
+                <vmm:LayoutSettingPanel DataContext="{Binding LayoutSetting}" />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <vmm:TabHeaderIconText Text="{DynamicResource TopBar_Setting_Effects}"
+                                           IconKind="Lightbulb"
+                                           />
+                </TabItem.Header>
+                <vmm:LightSettingPanel DataContext="{Binding LightSetting}" />
+            </TabItem>
+            <TabItem>
+                <TabItem.Header>
+                    <!-- NOTE: "Word to Motion"が正式名だが、長すぎるのでアイコンにしておく-->
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <md:PackIcon Grid.Column="0"
+                                     Width="23" Height="23"
+                                     VerticalAlignment="Center"
+                                     Kind="ABC"/>
+                        <md:PackIcon Grid.Column="1"
+                                     Width="16" Height="16"
+                                     Margin="2,0,0,0"
+                                     VerticalAlignment="Center"                                 
+                                     Kind="ArrowRightBold"/>
+                        <md:PackIcon Grid.Column="2"
+                                     Width="20" Height="20"
+                                     Margin="-2,1,0,0"
+                                     VerticalAlignment="Center"
+                                     Kind="HumanHandsup">
+                        </md:PackIcon>
+                    </Grid>
+                </TabItem.Header>
+                <vmm:WordToMotionSettingPanel DataContext="{Binding WordToMotionSetting}" />
+            </TabItem>
+        </dragablz:TabablzControl>
+    </md:DialogHost>
 </Window>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
@@ -133,7 +133,7 @@
         private ActionCommand? _resetSettingCommand = null;
         public ActionCommand ResetSettingCommand
             => _resetSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetToDefault)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetToDefault)
                 );
 
         public override void ResetToDefault()

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/Helper/DialogHelperViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/Helper/DialogHelperViewModel.cs
@@ -1,0 +1,59 @@
+﻿namespace Baku.VMagicMirrorConfig
+{
+    /// <summary>
+    /// ダイアログを表示してくれるすごいやつだよ
+    /// </summary>
+    public class DialogHelperViewModel : ViewModelBase
+    {
+        private DialogHelperViewModel() { }
+        private static DialogHelperViewModel? _instance;
+        public static DialogHelperViewModel Instance
+            => _instance ??= new DialogHelperViewModel();
+
+        private string _title = "";
+        public string Title
+        {
+            get => _title;
+            set => SetValue(ref _title, value);
+        }
+
+        private string _content = "";
+        public string Content
+        {
+            get => _content;
+            set => SetValue(ref _content, value);
+        }
+
+        private bool _isOpen = false;
+        public bool IsOpen
+        {
+            get => _isOpen;
+            set => SetValue(ref _isOpen, value);
+        }
+
+        private bool _canCancel = false;
+        public bool CanCancel
+        {
+            get => _canCancel;
+            set => SetValue(ref _canCancel, value);
+        }
+
+        private ActionCommand? _okCommand;
+        public ActionCommand OKCommand
+            => _okCommand ??= new ActionCommand(OkAndCloseDialog);
+        private void OkAndCloseDialog()
+        {
+            MessageBoxWrapper.Instance.SetDialogResult(true);
+            IsOpen = false;
+        }
+ 
+        private ActionCommand? _cancelCommand;
+        public ActionCommand CancelCommand
+            => _cancelCommand ??= new ActionCommand(CancelAndCloseDialog);
+        private void CancelAndCloseDialog()
+        {
+            MessageBoxWrapper.Instance.SetDialogResult(false);
+            IsOpen = false;
+        }
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LayoutSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LayoutSettingViewModel.cs
@@ -413,7 +413,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetDeviceLayoutCommand = null;
         public ActionCommand ResetDeviceLayoutCommand
             => _resetDeviceLayoutCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetDeviceLayout)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetDeviceLayout)
                 );
         private void ResetDeviceLayout()
         {
@@ -423,7 +423,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetHidSettingCommand = null;
         public ActionCommand ResetHidSettingCommand
             => _resetHidSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetHidSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetHidSetting)
                 );
         private void ResetHidSetting()
         {
@@ -434,7 +434,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetCameraSettingCommand = null;
         public ActionCommand ResetCameraSettingCommand
             => _resetCameraSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetCameraSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetCameraSetting)
                 );
         private void ResetCameraSetting()
         {

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/LightSettingViewModel.cs
@@ -353,25 +353,25 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetLightSettingCommand = null;
         public ActionCommand ResetLightSettingCommand
             => _resetLightSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetLightSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetLightSetting)
                 );
 
         private ActionCommand? _resetShadowSettingCommand = null;
         public ActionCommand ResetShadowSettingCommand
             => _resetShadowSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetShadowSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetShadowSetting)
                 );
 
         private ActionCommand? _resetBloomSettingCommand = null;
         public ActionCommand ResetBloomSettingCommand
             => _resetBloomSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetBloomSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetBloomSetting)
                 );
 
         private ActionCommand? _resetWindSettingCommand = null;
         public ActionCommand ResetWindSettingCommand
             => _resetWindSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetWindSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetWindSetting)
                 );
 
         private void ResetLightSetting()

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Xml.Serialization;

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -653,25 +653,25 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetFaceMotionSettingCommand = null;
         public ActionCommand ResetFaceMotionSettingCommand
             => _resetFaceMotionSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetFaceSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetFaceSetting)
                 );
 
         private ActionCommand? _resetArmMotionSettingCommand = null;
         public ActionCommand ResetArmMotionSettingCommand
             => _resetArmMotionSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetArmSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetArmSetting)
                 );
 
         private ActionCommand? _resetHandMotionSettingCommand = null;
         public ActionCommand ResetHandMotionSettingCommand
             => _resetHandMotionSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetHandSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetHandSetting)
                 );
 
         private ActionCommand? _resetWaitMotionSettingCommand = null;
         public ActionCommand ResetWaitMotionSettingCommand
             => _resetWaitMotionSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetWaitMotionSetting)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetWaitMotionSetting)
                 );
 
         private void ResetFaceSetting()

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
@@ -211,7 +211,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetBackgroundColorSettingCommand = null;
         public ActionCommand ResetBackgroundColorSettingCommand
             => _resetBackgroundColorSettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetBackgroundColor)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetBackgroundColor)
                 );
 
         private void ResetBackgroundColor()
@@ -224,7 +224,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetOpacitySettingCommand = null;
         public ActionCommand ResetOpacitySettingCommand
             => _resetOpacitySettingCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(ResetOpacity)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(ResetOpacity)
                 );
 
         private void ResetOpacity()

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionItemViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionItemViewModel.cs
@@ -190,7 +190,7 @@ namespace Baku.VMagicMirrorConfig
 
         private ActionCommand? _deleteCommand;
         public ActionCommand DeleteCommand
-            => _deleteCommand ??= new ActionCommand(() => _parent.DeleteItem(this));
+            => _deleteCommand ??= new ActionCommand(async () => await _parent.DeleteItem(this));
 
         private ObservableCollection<string> _availableBuiltInClipNames
             = new ObservableCollection<string>();

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
@@ -2,7 +2,7 @@
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Windows;
+using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace Baku.VMagicMirrorConfig
@@ -223,16 +223,15 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
-        public void DeleteItem(WordToMotionItemViewModel item)
+        public async Task DeleteItem(WordToMotionItemViewModel item)
         {
             var indication = MessageIndication.DeleteWordToMotionItem(LanguageSelector.Instance.LanguageName);
-            var res = MessageBox.Show(
-                Application.Current.MainWindow,
-                string.Format(indication.Content, item.Word),
+            bool res = await MessageBoxWrapper.Instance.ShowAsync(
                 indication.Title,
-                MessageBoxButton.OKCancel
+                string.Format(indication.Content, item.Word),
+                MessageBoxWrapper.MessageBoxStyle.OKCancel
                 );
-            if (res == MessageBoxResult.OK)
+            if (res)
             {
                 _items.Remove(item);
                 RequestReload();
@@ -258,7 +257,7 @@ namespace Baku.VMagicMirrorConfig
         private ActionCommand? _resetByDefaultItemsCommand = null;
         public ActionCommand ResetByDefaultItemsCommand
             => _resetByDefaultItemsCommand ??= new ActionCommand(
-                () => SettingResetUtils.ResetSingleCategorySetting(LoadDefaultItems)
+                () => SettingResetUtils.ResetSingleCategorySettingAsync(LoadDefaultItems)
                 );
 
         public override void ResetToDefault()


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/pull/168

## 補足: ダイアログの差し替えについて

本PRでHotfixとしてOK/CancelスタイルのダイアログをMaterialDesignInXamlToolkitのものに差し替えてます。

これを今回入れてる経緯は以下のユースケースで起こるトラブルを防ぐためです。

* フリーレイアウトをオンにする
* フリーレイアウト中にデバイス配置がごちゃごちゃしてきたため、リセットボタンを押す
* 「設定をリセットしますか？」ダイアログが最前面にあるUnityウィンドウの背面に隠れてしまい、見かけ上WPF側が操作できなくなる