### PR TITLE
DirectInputコントローラの使用オプション

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -187,6 +187,7 @@ namespace Baku.VMagicMirrorConfig
         #region ゲームパッド
 
         public Message EnableGamepad(bool enable) => WithArg($"{enable}");
+        public Message PreferDirectInputGamepad(bool preferDirectInput) => WithArg($"{preferDirectInput}");
         public Message GamepadHeight(int height) => WithArg($"{height}");
         public Message GamepadHorizontalScale(int scale) => WithArg($"{scale}");
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -173,12 +173,13 @@ VRM File</sys:String>
     <sys:String x:Key="Layout_Gamepad">Gamepad</sys:String>
     
     <sys:String x:Key="Layout_GamepadEnable">Enable Input Capture</sys:String>
+    <sys:String x:Key="Layout_Gamepad_PreferDirectInput">Use DirectInput (check for DUAL SHOCK 4)</sys:String>
     <sys:String x:Key="Layout_GamepadDeviceNumber">Device Number</sys:String>
     
     <sys:String x:Key="Layout_GamepadHeight">Height [cm]</sys:String>
     <sys:String x:Key="Layout_GamepadHorizontalScale">Size [%]</sys:String>
-    <sys:String x:Key="Layout_GamepadVisible">Visible</sys:String>
-    <sys:String x:Key="Layout_GamepadLeanMotion">Lean character by directional input</sys:String>
+    <sys:String x:Key="Layout_GamepadVisible">Visible</sys:String>    
+    <sys:String x:Key="Layout_GamepadLeanMotion">Lean character by directional input</sys:String>    
 
     <sys:String x:Key="Layout_GamepadLean">Lean by Stick</sys:String>
     <sys:String x:Key="Layout_GamepadLean_None">None</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -175,6 +175,7 @@
     <sys:String x:Key="Layout_Gamepad">ゲームパッド</sys:String>
     
     <sys:String x:Key="Layout_GamepadEnable">ゲームパッド入力のキャプチャを有効化</sys:String>
+    <sys:String x:Key="Layout_Gamepad_PreferDirectInput">DirectInputを使用 (DUAL SHOCK 4を使う場合オン)</sys:String>
     <sys:String x:Key="Layout_GamepadDeviceNumber">デバイス番号</sys:String>
     
     <sys:String x:Key="Layout_GamepadVisible">ゲームパッドを表示</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -36,6 +36,9 @@ VRMSpringBone-Optimize: https://github.com/malaybaku/VRMSpringBone-Optimize
         
 MidiJack (Original) https://github.com/keijiro/MidiJack
 MidiJack (Forked) https://github.com/malaybaku/MidiJack
+       
+SharpDX: https://github.com/sharpdx/SharpDX
+        
     </sys:String>
 
     <sys:String x:Key="OpenSourceLicenses" xml:space="preserve">
@@ -362,6 +365,18 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.        
+        
+        
+        SharpDX
+        
+Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         
     </sys:String>
 </ResourceDictionary>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/LayoutSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/LayoutSettingPanel.xaml
@@ -285,6 +285,14 @@
                                   >
                             <TextBlock Text="{DynamicResource Layout_GamepadEnable}"/>
                         </CheckBox>
+                        <CheckBox Margin="40,0,0,0"
+                                  VerticalAlignment="Center"
+                                  VerticalContentAlignment="Center"
+                                  IsEnabled="{Binding Gamepad.GamepadEnabled}"
+                                  IsChecked="{Binding Gamepad.PreferDirectInputGamepad}"
+                                  >
+                            <TextBlock Text="{DynamicResource Layout_Gamepad_PreferDirectInput}"/>
+                        </CheckBox>
 
                         <CheckBox Margin="20,2"
                               VerticalContentAlignment="Center"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/GamepadSettingViewModel.cs
@@ -24,6 +24,18 @@
                 }
             }
         }
+        private bool _preferDirectInputGamepad = false;
+        public bool PreferDirectInputGamepad
+        {
+            get => _preferDirectInputGamepad;
+            set
+            {
+                if (SetValue(ref _preferDirectInputGamepad, value))
+                {
+                    SendMessage(MessageFactory.Instance.PreferDirectInputGamepad(PreferDirectInputGamepad));
+                }
+            }
+        }
 
         private bool _visibility = false;
         public bool GamepadVisibility
@@ -139,6 +151,7 @@
         public override void ResetToDefault()
         {
             GamepadEnabled = true;
+            PreferDirectInputGamepad = false;
             GamepadVisibility = false;
 
             GamepadLeanNone = false;


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/201

UI側では以下のことだけ配慮して、他はあんまり関知しない。単にIPC対象のチェックボックスが一つ増えてるだけ。

- Unity側にXInputとDirectInputどちらを使うか選ばせる
- デフォルトではXInputを使わせる
