### PR TITLE
肩モーションの補正オプションをデフォルト有効扱いで追加

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -78,6 +78,7 @@ namespace Baku.VMagicMirrorConfig
         public Message HandYOffsetAfterKeyDown(int offsetCentimeter) => WithArg($"{offsetCentimeter}");
 
         public Message EnableHidArmMotion(bool enable) => WithArg($"{enable}");
+        public Message EnableShoulderMotionModify(bool enable) => WithArg($"{enable}");
         public Message SetWaistWidth(int waistWidthCentimeter) => WithArg($"{waistWidthCentimeter}");
         public Message SetElbowCloseStrength(int strengthPercent) => WithArg($"{strengthPercent}");
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -141,6 +141,7 @@ If the face tracking works correctly, please ignore this warning.
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">Arm</sys:String>    
     <sys:String x:Key="Motion_Arm_EnableHidMotion">Enable Typing / Mouse Motion</sys:String>
+    <sys:String x:Key="Motion_Arm_EnableShoulderModify">Modify shoulder motion</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand">Enable mouse motion to FPS assumed mode</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand_Tooltip">When checked right hand motion during playing FPS become more natural, but screen touch or pen tablet operation become become slow</sys:String>
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -143,6 +143,7 @@
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">腕・ひじ</sys:String>
     <sys:String x:Key="Motion_Arm_EnableHidMotion">タイピング / マウス動作を反映</sys:String>
+    <sys:String x:Key="Motion_Arm_EnableShoulderModify">肩モーションの補正を有効化</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand">右手のマウス動作をFPS対策モードにする</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand_Tooltip">オンにするとPC用のFPSを遊ぶときのマウス動作が自然になりますが、ペンタブ作業や画面タッチへの反応が悪くなります。</sys:String>
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -373,10 +373,17 @@
                                 />
                     </StackPanel>
 
-                    <CheckBox Margin="15,5,15,10" 
+                    <CheckBox Margin="15,5,15,2.5" 
                               Content="{DynamicResource Motion_Arm_EnableHidMotion}"
                               IsChecked="{Binding EnableHidArmMotion}"
                               />
+
+
+                    <CheckBox Margin="15,2.5,15,10" 
+                              Content="{DynamicResource Motion_Arm_EnableShoulderModify}"
+                              IsChecked="{Binding EnableShoulderMotionModify}"
+                              />
+
 
                     <Grid Margin="5,0,0,10">
                         <Grid.RowDefinitions>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -505,6 +505,19 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
+        private bool _enableShoulderMotionModify = true;
+        public bool EnableShoulderMotionModify
+        {
+            get => _enableShoulderMotionModify;
+            set
+            {
+                if (SetValue(ref _enableShoulderMotionModify, value))
+                {
+                    SendMessage(MessageFactory.Instance.EnableShoulderMotionModify(EnableShoulderMotionModify));
+                }
+            }
+        }
+
         private int _waistWidth = 30;
         public int WaistWidth
         {
@@ -763,6 +776,7 @@ namespace Baku.VMagicMirrorConfig
         private void ResetArmSetting()
         {
             EnableHidArmMotion = true;
+            EnableShoulderMotionModify = true;
             WaistWidth = 30;
             ElbowCloseStrength = 30;
             EnableFpsAssumedRightHand = false;


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/240 について、デフォルトで有効機能として入れつつ無効化もサポートするための更新です。

無効化したいモチベはこんな感じ。

- ぐりぐり動きすぎてキモいと思う人がいる可能性
- 肩ボーンを下手に動かすと破綻するモデルがあったらヤダ