### PR TITLE
VRoidSDK用のいろいろ

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -281,5 +281,11 @@ namespace Baku.VMagicMirrorConfig
 
         #endregion
 
+        #region VRoid SDK
+
+        public Message OpenVRoidSdkUi() => NoArg();
+
+        #endregion
+
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -284,7 +284,9 @@ namespace Baku.VMagicMirrorConfig
         #region VRoid SDK
 
         public Message OpenVRoidSdkUi() => NoArg();
-
+        public Message CloseVRoidSdkUi() => NoArg();
+        public Message RequestLoadVRoidWithId(string modelId) => WithArg(modelId);
+        
         #endregion
 
     }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -284,7 +284,6 @@ namespace Baku.VMagicMirrorConfig
         #region VRoid SDK
 
         public Message OpenVRoidSdkUi() => NoArg();
-        public Message CloseVRoidSdkUi() => NoArg();
         public Message RequestLoadVRoidWithId(string modelId) => WithArg(modelId);
         
         #endregion

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/ReceiveMessageNames.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/ReceiveMessageNames.cs
@@ -12,5 +12,7 @@
 
         public const string MidiNoteOn = nameof(MidiNoteOn);
 
+        public const string VRoidModelLoadCompleted = nameof(VRoidModelLoadCompleted);
+        public const string VRoidModelLoadCanceled = nameof(VRoidModelLoadCanceled);
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
@@ -133,8 +133,8 @@
                 "VRoid Hubに接続中",
                 "キャラクターウィンドウ上でモデルを選択するか、またはキャンセルしてください。"),
             _ => new MessageIndication(
-                "Connect to VRoid Hub",
-                "Select model to load, or `Cancel` to cancel operation."),
+                "Connecting to VRoid Hub",
+                "Select model to load, or cancel operation."),
         };
 
         public static MessageIndication ShowLoadingPreviousVRoid(Languages lang) => lang switch
@@ -143,8 +143,8 @@
                 "VRoid Hubに接続中",
                 "前回使用したモデルのロードを試みています。モデルをロードするか、またはキャンセルしてください。"),
             _ => new MessageIndication(
-                "Connect to VRoid Hub",
-                "Searching avatar used in previous time. Click `Cancel` to cancel operation."),
+                "Connecting to VRoid Hub",
+                "Trying to load avatar used in previous time. Select model or cancel operation."),
         };
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
@@ -21,7 +21,19 @@
 
         public static MessageIndication ResetSingleCategoryConfirmation(string languageName)
             => ResetSingleCategoryConfirmation(LanguageSelector.StringToLanguage(languageName));
+        public static MessageIndication ShowVRoidSdkUi(string languageName)
+            => ShowVRoidSdkUi(LanguageSelector.StringToLanguage(languageName));
 
+        public static MessageIndication ShowLoadingPreviousVRoid(string languageName)
+            => ShowLoadingPreviousVRoid(LanguageSelector.StringToLanguage(languageName));
+
+        /// <summary>
+        /// NOTE: Contentのほうがフォーマット文字列なのでstring.Formatで消すアイテムの名前を指定して完成させること！
+        /// string.Format(res.Content, "itemName")
+        /// みたいな。
+        /// </summary>
+        /// <param name="languageName"></param>
+        /// <returns></returns>
         public static MessageIndication ErrorLoadSetting(string languageName)
             => ErrorLoadSetting(LanguageSelector.StringToLanguage(languageName));
 
@@ -79,13 +91,6 @@
                 ),
         };
 
-        /// <summary>
-        /// NOTE: Contentのほうがフォーマット文字列なのでstring.Formatで消すアイテムの名前を指定して完成させること！
-        /// string.Format(res.Content, "itemName")
-        /// みたいな。
-        /// </summary>
-        /// <param name="languageName"></param>
-        /// <returns></returns>
         public static MessageIndication ErrorLoadSetting(Languages lang) => lang switch
         {
             Languages.Japanese => new MessageIndication(
@@ -120,6 +125,26 @@
                 "Clear Blend Shape Setting",
                 "Are you sure to clear the blend shape setting of '{0}'?"
                 ),
+        };
+
+        public static MessageIndication ShowVRoidSdkUi(Languages lang) => lang switch
+        {
+            Languages.Japanese => new MessageIndication(
+                "VRoid Hubに接続中",
+                "VRoid Hub上でモデルを選択するか、または「キャンセル」で操作を中止できます。"),
+            _ => new MessageIndication(
+                "Connect to VRoid Hub",
+                "Select model to load, or `Cancel` to cancel operation."),
+        };
+
+        public static MessageIndication ShowLoadingPreviousVRoid(Languages lang) => lang switch
+        {
+            Languages.Japanese => new MessageIndication(
+                "VRoid Hubに接続中",
+                "前回使用したモデルのロードを試みています。「キャンセル」で操作を中止できます。"),
+            _ => new MessageIndication(
+                "Connect to VRoid Hub",
+                "Searching avatar used in previous time. Click `Cancel` to cancel operation."),
         };
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
@@ -131,7 +131,7 @@
         {
             Languages.Japanese => new MessageIndication(
                 "VRoid Hubに接続中",
-                "VRoid Hub上でモデルを選択するか、または「キャンセル」で操作を中止できます。"),
+                "キャラクターウィンドウ上でモデルを選択するか、またはキャンセルしてください。"),
             _ => new MessageIndication(
                 "Connect to VRoid Hub",
                 "Select model to load, or `Cancel` to cancel operation."),
@@ -141,7 +141,7 @@
         {
             Languages.Japanese => new MessageIndication(
                 "VRoid Hubに接続中",
-                "前回使用したモデルのロードを試みています。「キャンセル」で操作を中止できます。"),
+                "前回使用したモデルのロードを試みています。モデルをロードするか、またはキャンセルしてください。"),
             _ => new MessageIndication(
                 "Connect to VRoid Hub",
                 "Searching avatar used in previous time. Click `Cancel` to cancel operation."),

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SaveData.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SaveData.cs
@@ -11,6 +11,8 @@
 
         public string? LastLoadedVrmFilePath { get; set; } = "";
 
+        public string? LastLoadedVRoidModelId { get; set; } = "";
+
         public bool AutoLoadLastLoadedVrm { get; set; } = false;
 
         public string? PreferredLanguageName { get; set; } = "";

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -18,11 +18,12 @@
     <sys:String x:Key="Home_LoadVrm">Load VRM</sys:String>
     <sys:String x:Key="Home_LoadVrmFromFile">Load File on PC</sys:String>    
     <sys:String x:Key="Home_LoadVrm_Or">or</sys:String>
-    <sys:String x:Key="Home_ConnectToVRoidHub">Load Model on VRoid Hub</sys:String>    
+    <sys:String x:Key="Home_ConnectToVRoidHub">Load from VRoid Hub</sys:String>    
     <sys:String x:Key="Home_OpenVRoidHub">Open VRoid Hub URL</sys:String>    
+    <sys:String x:Key="Home_VrmDragDropInstruction">Load VRM by Drag &amp; Drop</sys:String>
 
     <sys:String x:Key="Home_LoadVrmOnNextStartup">Load current VRM on next startup</sys:String>
-    <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">Adjust face settings after loading VRM</sys:String>
+    <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">Adjust face settings after load</sys:String>
     <sys:String x:Key="Home_AutoAdjust">Adjust Size by VRM</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">Manual</sys:String>
@@ -47,6 +48,7 @@
     <sys:String x:Key="Streaming_Window">Window</sys:String>
     <sys:String x:Key="Streaming_Face">Face</sys:String>
     <sys:String x:Key="Streaming_Motion">Motion</sys:String>       
+    <sys:String x:Key="Streaming_WordToMotion">Word to Motion</sys:String>
     <sys:String x:Key="Streaming_View">View</sys:String>
     <sys:String x:Key="Streaming_DeviceLayout">Device Layout</sys:String>
     <sys:String x:Key="Streaming_DeviceLayout_Reset">Reset</sys:String>
@@ -191,6 +193,9 @@ If the face tracking works correctly, please ignore this warning.
     <sys:String x:Key="Layout_HidVisible">Keyboard and Touch Pad Visible</sys:String>
     <sys:String x:Key="Layout_MidiVisible">MIDI Controller Visible</sys:String>
     <sys:String x:Key="Layout_MidiReadEnable">Use MIDI Controller for VMagicMirror</sys:String>
+    <sys:String x:Key="Layout_Hid_Streaming">Keyboard</sys:String>
+    <sys:String x:Key="Layout_Midi_Streaming">MIDI</sys:String>
+        
     <sys:String x:Key="Layout_HidReactToKeyboard">Enable keyboard motion</sys:String>
     <sys:String x:Key="Layout_HidReactToMouse">Enable mouse motion</sys:String>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -16,14 +16,14 @@
         
     <!-- Home -->
     <sys:String x:Key="Home_LoadVrm">Load VRM</sys:String>
-    <sys:String x:Key="Home_DragDropVrm" xml:space="preserve">Drag &amp; Drop
-VRM File</sys:String>
-    <sys:String x:Key="Home_LoadVrmOnNextStartup">Load current VRM on next startup</sys:String>
-    <sys:String x:Key="Home_AutoAdjust">Adjust Size by VRM</sys:String>
-    <sys:String x:Key="Home_RecommendVRoidHub">*If you do not have VRM on your PC yet: </sys:String>
+    <sys:String x:Key="Home_LoadVrmFromFile">Load File on PC</sys:String>    
+    <sys:String x:Key="Home_LoadVrm_Or">or</sys:String>
+    <sys:String x:Key="Home_ConnectToVRoidHub">Load Model on VRoid Hub</sys:String>    
     <sys:String x:Key="Home_OpenVRoidHub">Open VRoid Hub URL</sys:String>    
-    <sys:String x:Key="Home_ConnectToVRoidHub">Connect to VRoid Hub by App</sys:String>    
+
+    <sys:String x:Key="Home_LoadVrmOnNextStartup">Load current VRM on next startup</sys:String>
     <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">Adjust face settings after loading VRM</sys:String>
+    <sys:String x:Key="Home_AutoAdjust">Adjust Size by VRM</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">Manual</sys:String>
     <sys:String x:Key="Home_Manual_Open">Open Manual URL</sys:String>
@@ -39,6 +39,7 @@ VRM File</sys:String>
 
     <sys:String x:Key="Home_OssLicense">OSS License</sys:String>
     
+    <sys:String x:Key="Home_OtherSettings_Header">Other Preferences</sys:String>
     <sys:String x:Key="Home_ActivateOnStartupHeader">Start on Windows startup</sys:String>
     <sys:String x:Key="Home_ActivateOnStartup_OtherVerRegistered">*Other version VMagicMirror is already registered. If you check it, setting will be overwritten to start this version.</sys:String>
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -21,7 +21,8 @@ VRM File</sys:String>
     <sys:String x:Key="Home_LoadVrmOnNextStartup">Load current VRM on next startup</sys:String>
     <sys:String x:Key="Home_AutoAdjust">Adjust Size by VRM</sys:String>
     <sys:String x:Key="Home_RecommendVRoidHub">*If you do not have VRM on your PC yet: </sys:String>
-    <sys:String x:Key="Home_OpenVRoidHub">Open VRoid Hub</sys:String>    
+    <sys:String x:Key="Home_OpenVRoidHub">Open VRoid Hub URL</sys:String>    
+    <sys:String x:Key="Home_ConnectToVRoidHub">Connect to VRoid Hub by App</sys:String>    
     <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">Adjust face settings after loading VRM</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">Manual</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -20,6 +20,7 @@
     <sys:String x:Key="Home_LoadVrm_Or">または</sys:String>
     <sys:String x:Key="Home_ConnectToVRoidHub">VRoid Hubからロード</sys:String>    
     <sys:String x:Key="Home_OpenVRoidHub">ブラウザでVRoid Hubを開く</sys:String>
+    <sys:String x:Key="Home_VrmDragDropInstruction">ドラッグ &amp; ドロップでVRMをロード</sys:String>
 
     <sys:String x:Key="Home_LoadVrmOnNextStartup">次回の起動時にも同じVRMを読み込む</sys:String>
     <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">モデルロード時に表情を調整</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -21,7 +21,8 @@
     <sys:String x:Key="Home_LoadVrmOnNextStartup">次回の起動時にも同じVRMを読み込む</sys:String>
     <sys:String x:Key="Home_AutoAdjust">キャラ体格で補正</sys:String>
     <sys:String x:Key="Home_RecommendVRoidHub">※キャラクターのダウンロードがまだの場合: </sys:String>
-    <sys:String x:Key="Home_OpenVRoidHub">VRoid Hubを開く</sys:String>
+    <sys:String x:Key="Home_OpenVRoidHub">ブラウザでVRoid Hubを開く</sys:String>
+    <sys:String x:Key="Home_ConnectToVRoidHub">VRoid Hubに接続</sys:String>    
     <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">モデルロード時に表情を調整</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">使い方</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -16,14 +16,14 @@
     
     <!-- Home -->
     <sys:String x:Key="Home_LoadVrm">VRMロード</sys:String>
-    <sys:String x:Key="Home_DragDropVrm" xml:space="preserve">VRMファイルを
-ドラッグ&amp;ドロップ</sys:String>
-    <sys:String x:Key="Home_LoadVrmOnNextStartup">次回の起動時にも同じVRMを読み込む</sys:String>
-    <sys:String x:Key="Home_AutoAdjust">キャラ体格で補正</sys:String>
-    <sys:String x:Key="Home_RecommendVRoidHub">※キャラクターのダウンロードがまだの場合: </sys:String>
+    <sys:String x:Key="Home_LoadVrmFromFile">PC上のファイルをロード</sys:String>    
+    <sys:String x:Key="Home_LoadVrm_Or">または</sys:String>
+    <sys:String x:Key="Home_ConnectToVRoidHub">VRoid Hubからロード</sys:String>    
     <sys:String x:Key="Home_OpenVRoidHub">ブラウザでVRoid Hubを開く</sys:String>
-    <sys:String x:Key="Home_ConnectToVRoidHub">VRoid Hubに接続</sys:String>    
+
+    <sys:String x:Key="Home_LoadVrmOnNextStartup">次回の起動時にも同じVRMを読み込む</sys:String>
     <sys:String x:Key="Home_AutoAdjustFaceParameterOnLoad">モデルロード時に表情を調整</sys:String>
+    <sys:String x:Key="Home_AutoAdjust">キャラ体格で補正</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">使い方</sys:String>
     <sys:String x:Key="Home_Manual_Open">マニュアルのURLにアクセス</sys:String>
@@ -38,7 +38,8 @@
     <sys:String x:Key="Home_LoadPrevSetting">旧バージョンの設定をロード</sys:String>
         
     <sys:String x:Key="Home_OssLicense">OSS License</sys:String>
-    
+
+    <sys:String x:Key="Home_OtherSettings_Header">その他の設定</sys:String>
     <sys:String x:Key="Home_ActivateOnStartupHeader">Windowsの起動後にスタート</sys:String>
     <sys:String x:Key="Home_ActivateOnStartup_OtherVerRegistered">※他バージョンのVMagicMirrorが自動で起動するように登録されています。チェックをオンにすると、このバージョンを起動するよう設定を上書きします。</sys:String>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/DragDropToCommandBehavior.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/DragDropToCommandBehavior.cs
@@ -20,6 +20,16 @@ namespace Baku.VMagicMirrorConfig
             set => SetValue(DropCommandProperty, value);
         }
 
+        public Visibility InstructionVisibility
+        {
+            get => (Visibility)GetValue(InstructionVisibilityProperty);
+            set
+            {
+                LogOutput.Instance.Write($"Set DragDrop InstrcutionVisibility, value = {value}");
+                SetValue(InstructionVisibilityProperty, value);
+            }
+        }       
+
         /// <summary>
         /// <see cref="DropCommand"/>の依存関係プロパティです。
         /// </summary>
@@ -28,6 +38,14 @@ namespace Baku.VMagicMirrorConfig
                 nameof(DropCommand),
                 typeof(ICommand),
                 typeof(DragDropToCommandBehavior)
+                );
+
+        public static readonly DependencyProperty InstructionVisibilityProperty
+            = DependencyProperty.RegisterAttached(
+                nameof(InstructionVisibility),
+                typeof(Visibility),
+                typeof(DragDropToCommandBehavior),
+                new PropertyMetadata(Visibility.Collapsed)
                 );
 
         protected override void OnAttached()
@@ -55,6 +73,8 @@ namespace Baku.VMagicMirrorConfig
                 ? DragDropEffects.Copy
                 : DragDropEffects.None;
 
+            InstructionVisibility = (e.Effects == DragDropEffects.Copy) ? Visibility.Visible : Visibility.Collapsed;
+
             e.Handled = true;
         }
 
@@ -68,13 +88,14 @@ namespace Baku.VMagicMirrorConfig
                     (e.Data.GetData(DataFormats.FileDrop) as string[])?[0]
                     );
             }
+
+            InstructionVisibility = Visibility.Collapsed;
         }
 
         private void OnDragLeave(object sender, DragEventArgs e)
         {
-            //何もしない
+            LogOutput.Instance.Write($"DragLeave, elem == null ? {InstructionVisibility == null}");
+            InstructionVisibility = Visibility.Collapsed;
         }
-
-
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
@@ -53,6 +53,9 @@ namespace Baku.VMagicMirrorConfig
             OK,
             OKCancel,
             Cancel,
+            //NOTE: NoneはUnityの特定操作が終わるまでUIをガードしたいときに使う。
+            //表示したダイアログはSetDialogResultで閉じる必要がある。
+            None,
         }
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Code/MessageBoxWrapper.cs
@@ -21,10 +21,13 @@ namespace Baku.VMagicMirrorConfig
         /// <returns></returns>
         public Task<bool> ShowAsync(string title, string content, MessageBoxStyle style)
         {
-            DialogHelperViewModel.Instance.Title = title;
-            DialogHelperViewModel.Instance.Content = content;
-            DialogHelperViewModel.Instance.CanCancel = (style == MessageBoxStyle.OKCancel);
-            DialogHelperViewModel.Instance.IsOpen = true;
+            var vm = DialogHelperViewModel.Instance;
+
+            vm.Title = title;
+            vm.Content = content;
+            vm.CanOk = (style == MessageBoxStyle.OK || style == MessageBoxStyle.OKCancel);
+            vm.CanCancel = (style == MessageBoxStyle.Cancel || style == MessageBoxStyle.OKCancel);
+            vm.IsOpen = true;
 
             var result = new TaskCompletionSource<bool>();
             _dialogTasks.Enqueue(result);
@@ -32,7 +35,8 @@ namespace Baku.VMagicMirrorConfig
         }
 
         /// <summary>
-        /// ダイアログの結果を設定します。DialogHelperViewModelから呼び出します。
+        /// ダイアログの結果を設定します。UIがDialogHelperViewModelから呼び出すか、
+        /// またはプログラム的にダイアログを閉じたいときもここを呼び出します。
         /// </summary>
         /// <param name="result"></param>
         public void SetDialogResult(bool result)
@@ -48,6 +52,7 @@ namespace Baku.VMagicMirrorConfig
         {
             OK,
             OKCancel,
+            Cancel,
         }
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
@@ -10,6 +10,7 @@
              d:DataContext="{x:Type vmm:MainWindowViewModel}"
              d:DesignWidth="550"
              d:DesignHeight="470"
+             AllowDrop="True"
              >
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
@@ -23,13 +24,13 @@
             <Setter Property="Padding" Value="5"/>
         </Style>
     </UserControl.Resources>
+    <!-- このUI全域に対してVRMをドロップできるようにする -->
+    <i:Interaction.Behaviors>
+        <vmm:DragDropToCommandBehavior DropCommand="{Binding LoadVrmByFilePathCommand}"/>
+    </i:Interaction.Behaviors>
     <ScrollViewer VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   >
-        <!-- このUI全域に対してVRMをドロップできるようにする -->
-        <i:Interaction.Behaviors>
-            <vmm:DragDropToCommandBehavior DropCommand="{Binding LoadVrmByFilePathCommand}"/>
-        </i:Interaction.Behaviors>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
@@ -9,227 +9,299 @@
              mc:Ignorable="d"
              d:DataContext="{x:Type vmm:MainWindowViewModel}"
              d:DesignWidth="550"
-             d:DesignHeight="400"
+             d:DesignHeight="470"
              >
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <Style TargetType="md:PackIcon" x:Key="HeaderPackIcon">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Width" Value="20"/>
+            <Setter Property="Height" Value="20"/>
+        </Style>
+        <Style TargetType="md:Card">
+            <Setter Property="Margin" Value="5"/>
+            <Setter Property="Padding" Value="5"/>
+        </Style>
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   >
-        <StackPanel Margin="0">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
-                    <TextBlock Style="{StaticResource HeaderText}"
-                               Text="{DynamicResource Home_LoadVrm}"
-                               Margin="10,10,10,5"
-                               />
+        <!-- このUI全域に対してVRMをドロップできるようにする -->
+        <i:Interaction.Behaviors>
+            <vmm:DragDropToCommandBehavior DropCommand="{Binding LoadVrmByFilePathCommand}"/>
+        </i:Interaction.Behaviors>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0" Margin="0,5">
+                <md:Card Padding="5" Margin="5">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <md:PackIcon Style="{StaticResource HeaderPackIcon}"
+                                         Kind="Human"/>
+                            <TextBlock Style="{StaticResource HeaderText}"
+                                       Text="{DynamicResource Home_LoadVrm}"
+                                       Margin="5"
+                                       />
+                        </StackPanel>
 
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition/>
-                            <ColumnDefinition/>
-                        </Grid.ColumnDefinitions>
-                        <Button Grid.Column="0"
-                                HorizontalAlignment="Stretch"
+                        <Button HorizontalAlignment="Left"
                                 VerticalAlignment="Top"
-                                Width="NaN"
-                                Height="40"
-                                Margin="5"
+                                Width="180"
+                                Height="30"
+                                Margin="10,10,10,5"
                                 Padding="5"
                                 Command="{Binding LoadVrmCommand}"
                                 >
                             <StackPanel Style="{StaticResource IconTextSetStackPanel}">
                                 <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                         Kind="Human"
-                                         />
+                                                Kind="Folder"
+                                                />
                                 <TextBlock Style="{StaticResource IconSetSetText}"
-                                       Text="{DynamicResource Home_LoadVrm}"
-                                       />
+                                            Text="{DynamicResource Home_LoadVrmFromFile}"
+                                            />
                             </StackPanel>
                         </Button>
-                        <Border Grid.Column="1"
-                                Background="#00000001"
-                                AllowDrop="True"
-                                Margin="5">
-                            <i:Interaction.Behaviors>
-                                <vmm:DragDropToCommandBehavior DropCommand="{Binding LoadVrmByFilePathCommand}"/>
-                            </i:Interaction.Behaviors>
-                            <Grid>
-                                <Rectangle Stroke="{DynamicResource PrimaryHueMidBrush}"
-                                           StrokeThickness="1"
-                                           StrokeDashArray="1 2"
+
+                        <Grid Width="180" Height="20"
+                                HorizontalAlignment="Left"
+                                Margin="10,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Rectangle Grid.Column="0" Height="1" Fill="#767676"/>
+                            <TextBlock Grid.Column="1"
+                                       HorizontalAlignment="Center"
+                                       Text="{DynamicResource Home_LoadVrm_Or}"
+                                       Background="White"
+                                       Margin="5,0"
                                        />
-                                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center"
-                                           Text="{DynamicResource Home_DragDropVrm}"
-                                           
-                                           />
-                            </Grid>
-                        </Border>
-                    </Grid>
+                            <Rectangle Grid.Column="2" Height="1" Fill="#767676"/>
+                        </Grid>
+                        <Button HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Width="180"
+                                Height="30"
+                                Margin="10,5"
+                                Padding="5"
+                                Command="{Binding ConnectToVRoidHubCommand}"
+                                >
+                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                             Kind="TransitConnection"
+                                             />
+                                <!--Kind="TransitConnection"-->
+                                <TextBlock Style="{StaticResource IconSetSetText}"
+                                            Text="{DynamicResource Home_ConnectToVRoidHub}"
+                                            />
+                            </StackPanel>
+                        </Button>
 
-                    <TextBlock Text="{DynamicResource Home_RecommendVRoidHub}" Margin="10,5,10,0" />
-
-                    <Button HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Width="180"
-                            Margin="15,10"
-                            Command="{Binding ConnectToVRoidHubCommand}"
-                            >
-                        <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                            <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                         Kind="TransitConnection"
-                                         />
-                            <TextBlock Style="{StaticResource IconSetSetText}"
-                                       Text="{DynamicResource Home_ConnectToVRoidHub}"
-                                       />
-                        </StackPanel>
-                    </Button>
-
-                    <TextBlock Margin="15,0,10,20">
-                        <Hyperlink Command="{Binding OpenVRoidHubCommand}"
-                                   ToolTip="https://hub.vroid.com/">
-                            <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
-                        </Hyperlink>
-                    </TextBlock>
+                        <TextBlock Margin="39,0,10,10">
+                            <Hyperlink Command="{Binding OpenVRoidHubCommand}"
+                                        ToolTip="https://hub.vroid.com/">
+                                <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
+                            </Hyperlink>
+                        </TextBlock>
 
 
 
-                    <CheckBox Content="{DynamicResource Home_LoadVrmOnNextStartup}"
-                              Margin="15,10,15,5"
-                              IsChecked="{Binding AutoLoadLastLoadedVrm, Mode=TwoWay}"
-                              />
+                        <CheckBox Content="{DynamicResource Home_LoadVrmOnNextStartup}"
+                                  Margin="10,10,5,0"
+                                  IsChecked="{Binding AutoLoadLastLoadedVrm, Mode=TwoWay}"
+                                  />
 
-                    <CheckBox Content="{DynamicResource Home_AutoAdjustFaceParameterOnLoad}"
-                              IsChecked="{Binding AutoAdjustEyebrowOnLoaded}"
-                              Margin="15,0,15,10"                              
-                              />
+                        <CheckBox Content="{DynamicResource Home_AutoAdjustFaceParameterOnLoad}"
+                                  IsChecked="{Binding AutoAdjustEyebrowOnLoaded}"
+                                  Margin="10,0,5,10"                              
+                                  />
 
-                    <Button HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Width="180"
-                            Margin="15,10"
-                            Command="{Binding AutoAdjustCommand}"
-                            >
-                        <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                            <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                         Kind="AutoFix"
-                                         />
-                            <TextBlock Style="{StaticResource IconSetSetText}"
-                                       Text="{DynamicResource Home_AutoAdjust}"
-                                       />
-                        </StackPanel>
-                    </Button>
+                        <Button HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Width="180"
+                                Margin="10,5,5,10"
+                                Command="{Binding AutoAdjustCommand}"
+                                >
+                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                Kind="AutoFix"
+                                                />
+                                <TextBlock Style="{StaticResource IconSetSetText}"
+                                            Text="{DynamicResource Home_AutoAdjust}"
+                                            />
+                            </StackPanel>
+                        </Button>
 
-                    <TextBlock Style="{StaticResource HeaderText}"
-                               Margin="10,20,10,5"
-                               Text="Language"/>
+                    </StackPanel>
+                </md:Card>
 
-                    <StackPanel Orientation="Horizontal" Margin="15,5">
 
-                        <md:PackIcon Kind="Language"
-                                     VerticalAlignment="Center"
-                                     Width="18" Height="18"
-                                     />
-                        <ComboBox ItemsSource="{Binding AvailableLanguageNames}"
-                                  SelectedItem="{Binding LanguageName, Mode=TwoWay}"
-                                  Margin="10,5,5,5"
-                                  HorizontalAlignment="Left"
-                                  Width="200"
+                <md:Card>
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource HeaderText}"
+                                    Margin="5"
+                                    Text="{DynamicResource Home_OtherSettings_Header}"/>
+
+
+                        <DockPanel Margin="10,0" LastChildFill="True">
+
+                            <TextBlock Text="Language"/>
+
+                            <ComboBox ItemsSource="{Binding AvailableLanguageNames}"
+                                      SelectedItem="{Binding LanguageName, Mode=TwoWay}"
+                                      Margin="10,0"
+                                      HorizontalAlignment="Stretch"
+                                      MinWidth="100"
+                                      />
+                        </DockPanel>
+
+                        <CheckBox Margin="10,10,10,6"
+                                  Content="{DynamicResource Home_ActivateOnStartupHeader}"
+                                  IsChecked="{Binding ActivateOnStartup}"
                                   />
                     </StackPanel>
+                </md:Card>
+            </StackPanel>
 
-                    <CheckBox Margin="15,15,15,5"
-                              Content="{DynamicResource Home_ActivateOnStartupHeader}"
-                              IsChecked="{Binding ActivateOnStartup}"
-                              />
-                    <!--<TextBlock Margin="25,5,15,5"
-                               Text="{DynamicResource Home_ActivateOnStartup_OtherVerRegistered}"
-                               Visibility="{Binding OtherVersionRegisteredOnStartup, 
-                                                    Converter={StaticResource BooleanToVisibilityConverter}}"
-                               TextWrapping="Wrap"
-                               />-->
+            <StackPanel Grid.Column="1"
+                        Margin="0,5">
 
-                </StackPanel>
+                <md:Card>
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource HeaderText}"
+                                    Text="{DynamicResource Home_Manual_Header}"
+                                    Margin="5"
+                                    />
 
-                <StackPanel Grid.Column="1">
-
-                    <TextBlock Style="{StaticResource HeaderText}"
-                               Text="{DynamicResource Home_Manual_Header}"
-                               Margin="10,10,10,5"
-                               />
-
-                    <TextBlock Margin="10,5">
-                        <Hyperlink Command="{Binding OpenManualUrlCommand}"
-                                   ToolTip="https://malaybaku.github.io/VMagicMirror/">
-                            <Run Text="{DynamicResource Home_Manual_Open}"/>
-                        </Hyperlink>
-                    </TextBlock>
-
-                    <TextBlock Style="{StaticResource HeaderText}"
-                               Text="{DynamicResource Home_SettingFileIo}"
-                               Margin="10,20,10,5"
-                               />
-                    <Button HorizontalAlignment="Left"
-                            Width="215"
-                            Margin="15,10"
-                            Command="{Binding OpenSettingWindowCommand}"
-                            >
-                        <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                            <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                         Kind="Settings"
-                                         />
-                            <TextBlock Style="{StaticResource IconSetSetText}"
-                                       Text="{DynamicResource Home_OpenSetting}"
-                                       />
-                        </StackPanel>
-                    </Button>
-
-                    <TextBlock Style="{StaticResource HeaderText}"
-                           Text="{DynamicResource Home_SettingManagement}"
-                           Margin="10,20,10,5"
-                           />
-
-                    <StackPanel Orientation="Horizontal"
-                                Margin="15,10"
-                                >
-                        <Button Content="{DynamicResource Home_SaveSettingFile}" 
-                                HorizontalAlignment="Left"
-                                Width="100"
-                                Margin="0"
-                                Command="{Binding SaveSettingToFileCommand}"
-                                />
-
-                        <Button Content="{DynamicResource Home_LoadSettingFile}" 
-                            HorizontalAlignment="Left"
-                            Width="100"
-                            Margin="15,0,0,0"
-                            Command="{Binding LoadSettingFromFileCommand}"
-                            />
-
+                        <TextBlock Margin="10,5">
+                            <Hyperlink Command="{Binding OpenManualUrlCommand}"
+                                        ToolTip="https://malaybaku.github.io/VMagicMirror/">
+                                <Run Text="{DynamicResource Home_Manual_Open}"/>
+                            </Hyperlink>
+                        </TextBlock>                        
                     </StackPanel>
+                </md:Card>
 
-                    <Button Content="{DynamicResource Home_LoadPrevSetting}" 
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Width="215"
-                            Margin="15,10"
-                            Command="{Binding LoadPrevSettingCommand}"
-                            />
+                <md:Card>
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource HeaderText}"
+                                   Text="{DynamicResource Home_SettingFileIo}"
+                                   Margin="5"
+                                   />
 
-                    <Button Content="{DynamicResource Home_Reset}" 
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Width="100"
-                            Margin="15,10"
-                            Command="{Binding ResetToDefaultCommand}"
-                            />
-                </StackPanel>
-            </Grid>
-        </StackPanel>
+                        <Button HorizontalAlignment="Stretch"
+                                Width="NaN"
+                                Margin="10,10,10,5"
+                                Command="{Binding OpenSettingWindowCommand}"
+                                >
+                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                             Kind="Settings"
+                                             />
+                                <TextBlock Style="{StaticResource IconSetSetText}"
+                                           Text="{DynamicResource Home_OpenSetting}"
+                                           />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </md:Card>
+                <md:Card>
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <md:PackIcon Style="{StaticResource HeaderPackIcon}"
+                                            Kind="Camera"
+                                            />
+                            <TextBlock Text="{DynamicResource Streaming_Screenshot}"
+                                    Margin="5"
+                                    Style="{StaticResource HeaderText}"
+                                    />
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal">
+                            <Button Command="{Binding TakeScreenshotCommand}"
+                                Padding="0"
+                                Width="40"
+                                HorizontalAlignment="Left"
+                                >
+                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                            Kind="Camera"
+                                            />
+                            </Button>
+
+                            <Button Style="{StaticResource MaterialDesignFlatButton}"
+                                    Command="{Binding OpenScreenshotFolderCommand}"
+                                    Padding="0"
+                                    HorizontalAlignment="Left"
+                                    Margin="0"
+                                    >
+                                <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                            Kind="Folder"
+                                            />
+                                    <TextBlock Style="{StaticResource IconSetSetText}"
+                                        Text="{DynamicResource Streaming_Screenshot_OpenSaveFolder}"
+                                        />
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </StackPanel>
+                </md:Card>
+                
+                <md:Card>
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource HeaderText}"
+                                   Text="{DynamicResource Home_SettingManagement}"
+                                   Margin="0"
+                                   />
+
+                        <Grid Margin="10,10,10,11">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="15"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+
+                            <Button Grid.Row="0" Grid.Column="0"
+                                    Width="NaN"
+                                    Margin="0"
+                                    Content="{DynamicResource Home_SaveSettingFile}" 
+                                    Command="{Binding SaveSettingToFileCommand}"
+                                    />
+                            <Button Grid.Row="0" Grid.Column="2" 
+                                    Width="NaN"
+                                    Margin="0"
+                                    Content="{DynamicResource Home_LoadSettingFile}" 
+                                    Command="{Binding LoadSettingFromFileCommand}"
+                                    />
+
+                            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
+                                    Margin="0,15"
+                                    Width="NaN"
+                                    Content="{DynamicResource Home_LoadPrevSetting}" 
+                                    Command="{Binding LoadPrevSettingCommand}"
+                                    />
+
+                            <Button Grid.Row="2" Grid.Column="0"
+                                    Width="NaN"
+                                    Margin="0"
+                                    Content="{DynamicResource Home_Reset}" 
+                                    Command="{Binding ResetToDefaultCommand}"
+                                    />
+                        </Grid>
+                        
+                    </StackPanel>
+                </md:Card>
+            </StackPanel>
+        </Grid>
     </ScrollViewer>
 </UserControl>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
@@ -26,283 +26,298 @@
     </UserControl.Resources>
     <!-- このUI全域に対してVRMをドロップできるようにする -->
     <i:Interaction.Behaviors>
-        <vmm:DragDropToCommandBehavior DropCommand="{Binding LoadVrmByFilePathCommand}"/>
+        <vmm:DragDropToCommandBehavior x:Name="DragDropCommandBehavior"
+                                       DropCommand="{Binding LoadVrmByFilePathCommand}"
+                                       />
+        <!--InstructionVisibility="{Binding Visibility, ElementName=DragDropIndicator, Mode=OneWayToSource}"-->
     </i:Interaction.Behaviors>
-    <ScrollViewer VerticalScrollBarVisibility="Auto"
-                  HorizontalScrollBarVisibility="Disabled"
-                  >
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <StackPanel Grid.Column="0" Margin="0,5">
-                <md:Card Padding="5" Margin="5">
-                    <StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <md:PackIcon Style="{StaticResource HeaderPackIcon}"
-                                         Kind="Human"/>
-                            <TextBlock Style="{StaticResource HeaderText}"
-                                       Text="{DynamicResource Home_LoadVrm}"
-                                       Margin="5"
-                                       />
-                        </StackPanel>
-
-                        <Button HorizontalAlignment="Left"
-                                VerticalAlignment="Top"
-                                Width="180"
-                                Height="30"
-                                Margin="10,10,10,5"
-                                Padding="5"
-                                Command="{Binding LoadVrmCommand}"
-                                >
-                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                                Kind="Folder"
-                                                />
-                                <TextBlock Style="{StaticResource IconSetSetText}"
-                                            Text="{DynamicResource Home_LoadVrmFromFile}"
-                                            />
-                            </StackPanel>
-                        </Button>
-
-                        <Grid Width="180" Height="20"
-                                HorizontalAlignment="Left"
-                                Margin="10,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
-                            <Rectangle Grid.Column="0" Height="1" Fill="#767676"/>
-                            <TextBlock Grid.Column="1"
-                                       HorizontalAlignment="Center"
-                                       Text="{DynamicResource Home_LoadVrm_Or}"
-                                       Background="White"
-                                       Margin="5,0"
-                                       />
-                            <Rectangle Grid.Column="2" Height="1" Fill="#767676"/>
-                        </Grid>
-                        <Button HorizontalAlignment="Left"
-                                VerticalAlignment="Top"
-                                Width="180"
-                                Height="30"
-                                Margin="10,5"
-                                Padding="5"
-                                Command="{Binding ConnectToVRoidHubCommand}"
-                                >
-                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                             Kind="TransitConnection"
-                                             />
-                                <!--Kind="TransitConnection"-->
-                                <TextBlock Style="{StaticResource IconSetSetText}"
-                                            Text="{DynamicResource Home_ConnectToVRoidHub}"
-                                            />
-                            </StackPanel>
-                        </Button>
-
-                        <TextBlock Margin="39,0,10,10">
-                            <Hyperlink Command="{Binding OpenVRoidHubCommand}"
-                                        ToolTip="https://hub.vroid.com/">
-                                <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
-                            </Hyperlink>
-                        </TextBlock>
-
-
-
-                        <CheckBox Content="{DynamicResource Home_LoadVrmOnNextStartup}"
-                                  Margin="10,10,5,0"
-                                  IsChecked="{Binding AutoLoadLastLoadedVrm, Mode=TwoWay}"
-                                  />
-
-                        <CheckBox Content="{DynamicResource Home_AutoAdjustFaceParameterOnLoad}"
-                                  IsChecked="{Binding AutoAdjustEyebrowOnLoaded}"
-                                  Margin="10,0,5,10"                              
-                                  />
-
-                        <Button HorizontalAlignment="Left"
-                                VerticalAlignment="Top"
-                                Width="180"
-                                Margin="10,5,5,10"
-                                Command="{Binding AutoAdjustCommand}"
-                                >
-                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                                Kind="AutoFix"
-                                                />
-                                <TextBlock Style="{StaticResource IconSetSetText}"
-                                            Text="{DynamicResource Home_AutoAdjust}"
-                                            />
-                            </StackPanel>
-                        </Button>
-
-                    </StackPanel>
-                </md:Card>
-
-
-                <md:Card>
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource HeaderText}"
-                                    Margin="5"
-                                    Text="{DynamicResource Home_OtherSettings_Header}"/>
-
-
-                        <DockPanel Margin="10,0" LastChildFill="True">
-
-                            <TextBlock Text="Language"/>
-
-                            <ComboBox ItemsSource="{Binding AvailableLanguageNames}"
-                                      SelectedItem="{Binding LanguageName, Mode=TwoWay}"
-                                      Margin="10,0"
-                                      HorizontalAlignment="Stretch"
-                                      MinWidth="100"
-                                      />
-                        </DockPanel>
-
-                        <CheckBox Margin="10,10,10,6"
-                                  Content="{DynamicResource Home_ActivateOnStartupHeader}"
-                                  IsChecked="{Binding ActivateOnStartup}"
-                                  />
-                    </StackPanel>
-                </md:Card>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1"
-                        Margin="0,5">
-
-                <md:Card>
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource HeaderText}"
-                                    Text="{DynamicResource Home_Manual_Header}"
-                                    Margin="5"
-                                    />
-
-                        <TextBlock Margin="10,5">
-                            <Hyperlink Command="{Binding OpenManualUrlCommand}"
-                                        ToolTip="https://malaybaku.github.io/VMagicMirror/">
-                                <Run Text="{DynamicResource Home_Manual_Open}"/>
-                            </Hyperlink>
-                        </TextBlock>                        
-                    </StackPanel>
-                </md:Card>
-
-                <md:Card>
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource HeaderText}"
-                                   Text="{DynamicResource Home_SettingFileIo}"
-                                   Margin="5"
-                                   />
-
-                        <Button HorizontalAlignment="Stretch"
-                                Width="NaN"
-                                Margin="10,10,10,5"
-                                Command="{Binding OpenSettingWindowCommand}"
-                                >
-                            <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                             Kind="Settings"
-                                             />
-                                <TextBlock Style="{StaticResource IconSetSetText}"
-                                           Text="{DynamicResource Home_OpenSetting}"
+    <Grid>
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      >
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Margin="0,5">
+                    <md:Card Padding="5" Margin="5">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <md:PackIcon Style="{StaticResource HeaderPackIcon}"
+                                             Kind="Human"/>
+                                <TextBlock Style="{StaticResource HeaderText}"
+                                           Text="{DynamicResource Home_LoadVrm}"
+                                           Margin="5"
                                            />
                             </StackPanel>
-                        </Button>
-                    </StackPanel>
-                </md:Card>
-                <md:Card>
-                    <StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <md:PackIcon Style="{StaticResource HeaderPackIcon}"
-                                            Kind="Camera"
-                                            />
-                            <TextBlock Text="{DynamicResource Streaming_Screenshot}"
-                                    Margin="5"
-                                    Style="{StaticResource HeaderText}"
-                                    />
-                        </StackPanel>
 
-                        <StackPanel Orientation="Horizontal">
-                            <Button Command="{Binding TakeScreenshotCommand}"
-                                Padding="0"
-                                Width="40"
-                                HorizontalAlignment="Left"
-                                >
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                            Kind="Camera"
-                                            />
-                            </Button>
-
-                            <Button Style="{StaticResource MaterialDesignFlatButton}"
-                                    Command="{Binding OpenScreenshotFolderCommand}"
-                                    Padding="0"
-                                    HorizontalAlignment="Left"
-                                    Margin="0"
+                            <Button HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    Width="180"
+                                    Height="30"
+                                    Margin="10,10,10,5"
+                                    Padding="5"
+                                    Command="{Binding LoadVrmCommand}"
                                     >
                                 <StackPanel Style="{StaticResource IconTextSetStackPanel}">
                                     <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                            Kind="Folder"
-                                            />
+                                                    Kind="Folder"
+                                                    />
                                     <TextBlock Style="{StaticResource IconSetSetText}"
-                                        Text="{DynamicResource Streaming_Screenshot_OpenSaveFolder}"
+                                                Text="{DynamicResource Home_LoadVrmFromFile}"
+                                                />
+                                </StackPanel>
+                            </Button>
+
+                            <Grid Width="180" Height="20"
+                                    HorizontalAlignment="Left"
+                                    Margin="10,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition/>
+                                </Grid.ColumnDefinitions>
+                                <Rectangle Grid.Column="0" Height="1" Fill="#767676"/>
+                                <TextBlock Grid.Column="1"
+                                           HorizontalAlignment="Center"
+                                           Text="{DynamicResource Home_LoadVrm_Or}"
+                                           Background="White"
+                                           Margin="5,0"
+                                           />
+                                <Rectangle Grid.Column="2" Height="1" Fill="#767676"/>
+                            </Grid>
+                            <Button HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    Width="180"
+                                    Height="30"
+                                    Margin="10,5"
+                                    Padding="5"
+                                    Command="{Binding ConnectToVRoidHubCommand}"
+                                    >
+                                <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                 Kind="TransitConnection"
+                                                 />
+                                    <!--Kind="TransitConnection"-->
+                                    <TextBlock Style="{StaticResource IconSetSetText}"
+                                                Text="{DynamicResource Home_ConnectToVRoidHub}"
+                                                />
+                                </StackPanel>
+                            </Button>
+
+                            <TextBlock Margin="39,0,10,10">
+                                <Hyperlink Command="{Binding OpenVRoidHubCommand}"
+                                            ToolTip="https://hub.vroid.com/">
+                                    <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
+                                </Hyperlink>
+                            </TextBlock>
+
+
+
+                            <CheckBox Content="{DynamicResource Home_LoadVrmOnNextStartup}"
+                                      Margin="10,10,5,0"
+                                      IsChecked="{Binding AutoLoadLastLoadedVrm, Mode=TwoWay}"
+                                      />
+
+                            <CheckBox Content="{DynamicResource Home_AutoAdjustFaceParameterOnLoad}"
+                                      IsChecked="{Binding AutoAdjustEyebrowOnLoaded}"
+                                      Margin="10,0,5,10"                              
+                                      />
+
+                            <Button HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    Width="180"
+                                    Margin="10,5,5,10"
+                                    Command="{Binding AutoAdjustCommand}"
+                                    >
+                                <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                    Kind="AutoFix"
+                                                    />
+                                    <TextBlock Style="{StaticResource IconSetSetText}"
+                                                Text="{DynamicResource Home_AutoAdjust}"
+                                                />
+                                </StackPanel>
+                            </Button>
+
+                        </StackPanel>
+                    </md:Card>
+
+
+                    <md:Card>
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource HeaderText}"
+                                        Margin="5"
+                                        Text="{DynamicResource Home_OtherSettings_Header}"/>
+
+
+                            <DockPanel Margin="10,0" LastChildFill="True">
+
+                                <TextBlock Text="Language"/>
+
+                                <ComboBox ItemsSource="{Binding AvailableLanguageNames}"
+                                          SelectedItem="{Binding LanguageName, Mode=TwoWay}"
+                                          Margin="10,0"
+                                          HorizontalAlignment="Stretch"
+                                          MinWidth="100"
+                                          />
+                            </DockPanel>
+
+                            <CheckBox Margin="10,10,10,6"
+                                      Content="{DynamicResource Home_ActivateOnStartupHeader}"
+                                      IsChecked="{Binding ActivateOnStartup}"
+                                      />
+                        </StackPanel>
+                    </md:Card>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1"
+                            Margin="0,5">
+
+                    <md:Card>
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource HeaderText}"
+                                        Text="{DynamicResource Home_Manual_Header}"
+                                        Margin="5"
                                         />
+
+                            <TextBlock Margin="10,5">
+                                <Hyperlink Command="{Binding OpenManualUrlCommand}"
+                                            ToolTip="https://malaybaku.github.io/VMagicMirror/">
+                                    <Run Text="{DynamicResource Home_Manual_Open}"/>
+                                </Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
+                    </md:Card>
+
+                    <md:Card>
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource HeaderText}"
+                                       Text="{DynamicResource Home_SettingFileIo}"
+                                       Margin="5"
+                                       />
+
+                            <Button HorizontalAlignment="Stretch"
+                                    Width="NaN"
+                                    Margin="10,10,10,5"
+                                    Command="{Binding OpenSettingWindowCommand}"
+                                    >
+                                <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                 Kind="Settings"
+                                                 />
+                                    <TextBlock Style="{StaticResource IconSetSetText}"
+                                               Text="{DynamicResource Home_OpenSetting}"
+                                               />
                                 </StackPanel>
                             </Button>
                         </StackPanel>
-                    </StackPanel>
-                </md:Card>
-                
-                <md:Card>
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource HeaderText}"
-                                   Text="{DynamicResource Home_SettingManagement}"
-                                   Margin="0"
-                                   />
+                    </md:Card>
+                    <md:Card>
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <md:PackIcon Style="{StaticResource HeaderPackIcon}"
+                                                Kind="Camera"
+                                                />
+                                <TextBlock Text="{DynamicResource Streaming_Screenshot}"
+                                        Margin="5"
+                                        Style="{StaticResource HeaderText}"
+                                        />
+                            </StackPanel>
 
-                        <Grid Margin="10,10,10,11">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition Width="15"/>
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Command="{Binding TakeScreenshotCommand}"
+                                    Padding="0"
+                                    Width="40"
+                                    HorizontalAlignment="Left"
+                                    >
+                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                Kind="Camera"
+                                                />
+                                </Button>
 
-                            <Button Grid.Row="0" Grid.Column="0"
-                                    Width="NaN"
-                                    Margin="0"
-                                    Content="{DynamicResource Home_SaveSettingFile}" 
-                                    Command="{Binding SaveSettingToFileCommand}"
-                                    />
-                            <Button Grid.Row="0" Grid.Column="2" 
-                                    Width="NaN"
-                                    Margin="0"
-                                    Content="{DynamicResource Home_LoadSettingFile}" 
-                                    Command="{Binding LoadSettingFromFileCommand}"
-                                    />
+                                <Button Style="{StaticResource MaterialDesignFlatButton}"
+                                        Command="{Binding OpenScreenshotFolderCommand}"
+                                        Padding="0"
+                                        HorizontalAlignment="Left"
+                                        Margin="0"
+                                        >
+                                    <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                                        <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                                Kind="Folder"
+                                                />
+                                        <TextBlock Style="{StaticResource IconSetSetText}"
+                                            Text="{DynamicResource Streaming_Screenshot_OpenSaveFolder}"
+                                            />
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </md:Card>
 
-                            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
-                                    Margin="0,15"
-                                    Width="NaN"
-                                    Content="{DynamicResource Home_LoadPrevSetting}" 
-                                    Command="{Binding LoadPrevSettingCommand}"
-                                    />
+                    <md:Card>
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource HeaderText}"
+                                       Text="{DynamicResource Home_SettingManagement}"
+                                       Margin="0"
+                                       />
 
-                            <Button Grid.Row="2" Grid.Column="0"
-                                    Width="NaN"
-                                    Margin="0"
-                                    Content="{DynamicResource Home_Reset}" 
-                                    Command="{Binding ResetToDefaultCommand}"
-                                    />
-                        </Grid>
-                        
-                    </StackPanel>
-                </md:Card>
-            </StackPanel>
-        </Grid>
-    </ScrollViewer>
+                            <Grid Margin="10,10,10,11">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition Width="15"/>
+                                    <ColumnDefinition/>
+                                </Grid.ColumnDefinitions>
+
+                                <Button Grid.Row="0" Grid.Column="0"
+                                        Width="NaN"
+                                        Margin="0"
+                                        Content="{DynamicResource Home_SaveSettingFile}" 
+                                        Command="{Binding SaveSettingToFileCommand}"
+                                        />
+                                <Button Grid.Row="0" Grid.Column="2" 
+                                        Width="NaN"
+                                        Margin="0"
+                                        Content="{DynamicResource Home_LoadSettingFile}" 
+                                        Command="{Binding LoadSettingFromFileCommand}"
+                                        />
+
+                                <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
+                                        Margin="0,15"
+                                        Width="NaN"
+                                        Content="{DynamicResource Home_LoadPrevSetting}" 
+                                        Command="{Binding LoadPrevSettingCommand}"
+                                        />
+
+                                <Button Grid.Row="2" Grid.Column="0"
+                                        Width="NaN"
+                                        Margin="0"
+                                        Content="{DynamicResource Home_Reset}" 
+                                        Command="{Binding ResetToDefaultCommand}"
+                                        />
+                            </Grid>
+
+                        </StackPanel>
+                    </md:Card>
+                </StackPanel>
+            </Grid>
+        </ScrollViewer>
+        <Border x:Name="DragDropIndicator" 
+                Visibility="{Binding InstructionVisibility, ElementName=DragDropCommandBehavior, FallbackValue=Collapsed}"
+                Background="#80000000">
+            <TextBlock Foreground="White"
+                       FontSize="20"
+                       FontWeight="Bold"
+                       Text="{DynamicResource Home_VrmDragDropInstruction}"
+                       TextAlignment="Center"
+                       />
+        </Border>
+    </Grid>
 </UserControl>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/HomePanel.xaml
@@ -71,7 +71,33 @@
                             </Grid>
                         </Border>
                     </Grid>
-                    
+
+                    <TextBlock Text="{DynamicResource Home_RecommendVRoidHub}" Margin="10,5,10,0" />
+
+                    <Button HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            Width="180"
+                            Margin="15,10"
+                            Command="{Binding ConnectToVRoidHubCommand}"
+                            >
+                        <StackPanel Style="{StaticResource IconTextSetStackPanel}">
+                            <md:PackIcon Style="{StaticResource IconTextSetIcon}"
+                                         Kind="TransitConnection"
+                                         />
+                            <TextBlock Style="{StaticResource IconSetSetText}"
+                                       Text="{DynamicResource Home_ConnectToVRoidHub}"
+                                       />
+                        </StackPanel>
+                    </Button>
+
+                    <TextBlock Margin="15,0,10,20">
+                        <Hyperlink Command="{Binding OpenVRoidHubCommand}"
+                                   ToolTip="https://hub.vroid.com/">
+                            <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
+                        </Hyperlink>
+                    </TextBlock>
+
+
 
                     <CheckBox Content="{DynamicResource Home_LoadVrmOnNextStartup}"
                               Margin="15,10,15,5"
@@ -98,15 +124,6 @@
                                        />
                         </StackPanel>
                     </Button>
-
-                    <TextBlock Margin="10,5">
-                        <Run Text="{DynamicResource Home_RecommendVRoidHub}"/>
-                        <LineBreak/>
-                        <Hyperlink Command="{Binding OpenVRoidHubCommand}"
-                                   ToolTip="https://hub.vroid.com/">
-                            <Run Text="{DynamicResource Home_OpenVRoidHub}"/>
-                        </Hyperlink>
-                    </TextBlock>
 
                     <TextBlock Style="{StaticResource HeaderText}"
                                Margin="10,20,10,5"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d" 
              d:DataContext="{x:Type vmm:MainWindowViewModel}"
              d:DesignWidth="520"
-             d:DesignHeight="700"
+             d:DesignHeight="620"
              >
     <UserControl.Resources>
         <vmm:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
@@ -233,7 +233,8 @@
 
                         <md:Card Margin="15,5,5,0" 
                                  Visibility="{Binding MotionSetting.ShowInstallPathWarning,
-                                                      Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                      Converter={StaticResource BooleanToVisibilityConverter}, 
+                                                      FallbackValue=Collapsed}"
                                  ToolTip="{DynamicResource Motion_Face_FolderMaybeIncorrect_Tooltip}"
                                  HorizontalAlignment="Center"
                                  Background="{StaticResource SecondaryAccentBrush}" Padding="3">
@@ -276,7 +277,7 @@
                         </Button>
 
                         <TextBlock Text="{DynamicResource Motion_Eye_LookAtPoint}"
-                                    Margin="10,10,5,5"
+                                    Margin="10,13,5,5"
                                     />
 
                         <Grid Margin="10,3">
@@ -360,48 +361,6 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </Grid>
-                    </StackPanel>
-                </md:Card>
-
-                <md:Card>
-                    <StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <md:PackIcon Style="{StaticResource HeaderPackIcon}"
-                                            Kind="Camera"
-                                            />
-                            <TextBlock Text="{DynamicResource Streaming_Screenshot}"
-                                    Margin="5"
-                                    Style="{StaticResource HeaderText}"
-                                    />
-                        </StackPanel>
-
-                        <StackPanel Orientation="Horizontal">
-                            <Button Command="{Binding TakeScreenshotCommand}"
-                                Padding="0"
-                                Width="40"
-                                HorizontalAlignment="Left"
-                                >
-                                <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                            Kind="Camera"
-                                            />
-                            </Button>
-
-                            <Button Style="{StaticResource MaterialDesignFlatButton}"
-                                    Command="{Binding OpenScreenshotFolderCommand}"
-                                    Padding="0"
-                                    HorizontalAlignment="Left"
-                                    Margin="0"
-                                    >
-                                <StackPanel Style="{StaticResource IconTextSetStackPanel}">
-                                    <md:PackIcon Style="{StaticResource IconTextSetIcon}"
-                                            Kind="Folder"
-                                            />
-                                    <TextBlock Style="{StaticResource IconSetSetText}"
-                                        Text="{DynamicResource Streaming_Screenshot_OpenSaveFolder}"
-                                        />
-                                </StackPanel>
-                            </Button>
-                        </StackPanel>
                     </StackPanel>
                 </md:Card>
             </StackPanel>
@@ -637,7 +596,7 @@
 
                         <CheckBox Grid.Row="2" Grid.Column="0"
                                     Grid.ColumnSpan="3"
-                                    Margin="10,2" 
+                                    Margin="14,2,10,14" 
                                     Content="{DynamicResource Motion_Arm_EnablePresenterMotion}"
                                     IsChecked="{Binding MotionSetting.EnablePresenterMotion}"
                                     />

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
@@ -34,6 +34,8 @@
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Style="{StaticResource MaterialDesignFlatButton}"
                             Content="OK"
+                            Visibility="{Binding DialogHelper.CanOk,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
                             Command="{Binding DialogHelper.OKCommand}"
                             />
                     <Button Style="{StaticResource MaterialDesignFlatButton}"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
@@ -30,6 +30,8 @@
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Style="{StaticResource MaterialDesignFlatButton}"
                             Content="OK"
+                            Visibility="{Binding DialogHelper.CanOk,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
                             Command="{Binding DialogHelper.OKCommand}"
                             />
                     <Button Style="{StaticResource MaterialDesignFlatButton}"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/Helper/DialogHelperViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/Helper/DialogHelperViewModel.cs
@@ -31,6 +31,13 @@
             set => SetValue(ref _isOpen, value);
         }
 
+        private bool _canOk = true;
+        public bool CanOk
+        {
+            get => _canOk;
+            set => SetValue(ref _canOk, value);
+        }
+
         private bool _canCancel = false;
         public bool CanCancel
         {

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -77,7 +77,7 @@ namespace Baku.VMagicMirrorConfig
             switch (e.Command)
             {
                 case ReceiveMessageNames.VRoidModelLoadCompleted:
-                    //WPF側の「キャンセルできるよ」ダイアログはもう不要なので隠す
+                    //WPF側のダイアログによるUIガードを終了: _isVRoidHubUiActiveフラグは別のとこで折るのでここでは無視でOK
                     if (_isVRoidHubUiActive)
                     {
                         MessageBoxWrapper.Instance.SetDialogResult(false);
@@ -93,7 +93,7 @@ namespace Baku.VMagicMirrorConfig
                     }
                     break;
                 case ReceiveMessageNames.VRoidModelLoadCanceled:
-                    //NOTE: Unity側にキャンセルUIがあったらそれもちゃんとハンドルしますよ、という処理。
+                    //WPF側のダイアログによるUIガードを終了
                     if (_isVRoidHubUiActive)
                     {
                         MessageBoxWrapper.Instance.SetDialogResult(false);
@@ -296,7 +296,6 @@ namespace Baku.VMagicMirrorConfig
                 );
 
             //モデルロード完了またはキャンセルによってここに来るので、共通の処理をして終わり
-            MessageSender.SendMessage(MessageFactory.Instance.CloseVRoidSdkUi());
             _isVRoidHubUiActive = false;
             WindowSetting.IsTransparent = _windowTransparentOnConnectToVRoidHub;
         }
@@ -517,7 +516,7 @@ namespace Baku.VMagicMirrorConfig
             _windowTransparentOnConnectToVRoidHub = WindowSetting.IsTransparent;
             WindowSetting.IsTransparent = false;
 
-            //NOTE: ここでモデルIDを載せるのと、メッセージがちょっと違うこと以外は普通にVRoidのUIを出したときと同じフローに載せる
+            //NOTE: モデルIDを載せる以外は通常のUIオープンと同じフロー
             MessageSender.SendMessage(MessageFactory.Instance.RequestLoadVRoidWithId(_lastLoadedVRoidModelId));
 
             _isVRoidHubUiActive = true;
@@ -527,7 +526,6 @@ namespace Baku.VMagicMirrorConfig
                 );
 
             //モデルロード完了またはキャンセルによってここに来るので、共通の処理をして終わり
-            MessageSender.SendMessage(MessageFactory.Instance.CloseVRoidSdkUi());
             _isVRoidHubUiActive = false;
             WindowSetting.IsTransparent = _windowTransparentOnConnectToVRoidHub;
         }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -81,6 +81,7 @@ namespace Baku.VMagicMirrorConfig
                     if (_isVRoidHubUiActive)
                     {
                         MessageBoxWrapper.Instance.SetDialogResult(false);
+                        DialogHelper.IsOpen = false;
                     }
 
                     //ファイルパスではなくモデルID側を最新情報として覚えておく
@@ -97,6 +98,7 @@ namespace Baku.VMagicMirrorConfig
                     if (_isVRoidHubUiActive)
                     {
                         MessageBoxWrapper.Instance.SetDialogResult(false);
+                        DialogHelper.IsOpen = false;
                     }
                     break;
             }
@@ -522,7 +524,7 @@ namespace Baku.VMagicMirrorConfig
             _isVRoidHubUiActive = true;
             var message = MessageIndication.ShowLoadingPreviousVRoid(LanguageName);
             bool _ = await MessageBoxWrapper.Instance.ShowAsync(
-                message.Title, message.Content, MessageBoxWrapper.MessageBoxStyle.Cancel
+                message.Title, message.Content, MessageBoxWrapper.MessageBoxStyle.None
                 );
 
             //モデルロード完了またはキャンセルによってここに来るので、共通の処理をして終わり

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -292,7 +292,7 @@ namespace Baku.VMagicMirrorConfig
             _isVRoidHubUiActive = true;
             var message = MessageIndication.ShowVRoidSdkUi(LanguageName);
             bool _ = await MessageBoxWrapper.Instance.ShowAsync(
-                message.Title, message.Content, MessageBoxWrapper.MessageBoxStyle.Cancel
+                message.Title, message.Content, MessageBoxWrapper.MessageBoxStyle.None
                 );
 
             //モデルロード完了またはキャンセルによってここに来るので、共通の処理をして終わり

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WindowSettingViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Media;
 using System.Xml.Serialization;
 
@@ -347,5 +348,16 @@ namespace Baku.VMagicMirrorConfig
             //このリセットはあまり定数的ではないことに注意！
             ResetWindowPosition();
         }
+
+        #region Unity側にUIが出っぱなしの状態でexeを切ったときの復帰用API
+
+        /// <summary>
+        /// <see cref="TopMost"/>の値を変更しますが、プロセス間通信は行いません。
+        /// </summary>
+        /// <param name="topMost"></param>
+        public void SilentSetTopMost(bool topMost)
+            => SetValue(ref _topMost, topMost, nameof(TopMost));
+
+        #endregion
     }
 }


### PR DESCRIPTION
## 概要

- メイン: https://github.com/malaybaku/VMagicMirror/issues/126
- メイン以外:
    - 多言語化の抜けを修正
    - ホームタブを配信タブと同様にカードで区切ったUIに更新
    - 「スクリーンショット」を配信タブからホームタブに移動

以下2つのマナーにのっとってます。

- Unity側がVRoid Hub用のUIを表示している間はWPFの画面からジャマをしないようにする
- Unity側がVRoid Hubのモデルをロードしたとき、そのモデルの識別子(文字列)をWPF側が受け取ることがあるが、WPF側ではその文字列の詳細には関知しない。

## note: コードの公開状況について

- WPF側はVRoid Hubとのやりとりの詳細に関知しないため、GitHubに置くコードはすべて本番用のソースコードです。

## TODO

- GUIレイアウトが変わったので少なくともwebのGet Startedページで見直しが必要。
- 上記をやるとき、VRoid Hubに関してもweb側で文面直しが必要。