### PR TITLE
パーフェクトシンクを含むUIのfix

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/MessageIndication.cs
@@ -194,7 +194,7 @@
                 @"Detect missing BlendShapeClips for perfect sync.
 
 If your avatar looks normal, ignore this message. 
-Otherwise, close this dialog and see 'About Perfect Sync',
+Otherwise, close this dialog and see 'About Perfect Sync'
 to check how to setup the model.
 
 ---

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -69,8 +69,7 @@ During this mode, following features are disabled.
     <sys:String x:Key="ExTracker_Enable_PerfectSync">Use Perfect Sync</sys:String>
     <sys:String x:Key="ExTracker_PerfectSync_UseVRoidDefault">Perfect sync with VRoid's default setting</sys:String>
     <sys:String x:Key="ExTracker_HowTo_PerfectSync">About Perfect Sync (open web page)</sys:String>
-    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_Header">Please check model setup! </sys:String>
-    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_HeaderSub">(click for detail)</sys:String>
+    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_Header">The model does not support perfect sync (click for detail)</sys:String>
     
     <sys:String x:Key="ExTracker_Calibrate">Calibrate Face Pose</sys:String>
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -71,8 +71,7 @@
     <sys:String x:Key="ExTracker_Enable_PerfectSync">パーフェクトシンクを使用</sys:String>
     <sys:String x:Key="ExTracker_PerfectSync_UseVRoidDefault">VRoid用のデフォルト設定を使う(※VRoidモデルでのみ動作)</sys:String>
     <sys:String x:Key="ExTracker_HowTo_PerfectSync">パーフェクトシンクとは? (Webページを開きます)</sys:String>
-    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_Header">モデルのセットアップを確認して下さい！ </sys:String>
-    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_HeaderSub">(クリックで詳細)</sys:String>
+    <sys:String x:Key="ExTracker_PerfectSync_MissingBlendShape_Header">モデルがパーフェクトシンク未対応のようです (クリックで詳細)</sys:String>
 
     <sys:String x:Key="ExTracker_Calibrate">現在位置で顔をキャリブレーション</sys:String>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/ExternalTrackerPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/ExternalTrackerPanel.xaml
@@ -64,8 +64,7 @@
                             Margin="25,5"
                             Padding="5"
                             Width="NaN"
-                            Background="{StaticResource SecondaryAccentBrush}"
-                            BorderBrush="Transparent"
+                            Style="{StaticResource MaterialDesignOutlinedButton}"
                             Foreground="Black"
                             Visibility="{Binding ShouldNotifyMissingBlendShapeClipNames,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}"
@@ -78,13 +77,7 @@
                                          Foreground="{StaticResource PrimaryHueMidBrush}"
                                          />
                             <TextBlock Text="{DynamicResource ExTracker_PerfectSync_MissingBlendShape_Header}" 
-                                       FontWeight="Bold"
                                        Margin="3,0"
-                                       />
-                            <TextBlock Text="{DynamicResource ExTracker_PerfectSync_MissingBlendShape_HeaderSub}" 
-                                       FontWeight="Bold"
-                                       Margin="3,0"
-                                       Foreground="{StaticResource PrimaryHueMidBrush}"
                                        />
                         </StackPanel>
                     </Button>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -131,13 +131,10 @@ namespace Baku.VMagicMirrorConfig
             get => _enableFaceTracking;
             set
             {
-                if (_enableFaceTracking == value)
+                if (SetValue(ref _enableFaceTracking, value))
                 {
-                    return;
+                    SendMessage(MessageFactory.Instance.EnableFaceTracking(EnableFaceTracking));
                 }
-
-                _enableFaceTracking = value;
-                SendMessage(MessageFactory.Instance.EnableFaceTracking(EnableFaceTracking));
             }
         }
 


### PR DESCRIPTION
- モデルがパーフェクトシンク未対応のときの警告が強すぎたのでやんわりした言い方に変更
- 顔トラッキングのチェックボックスが(ViewModel側の問題で)正しくTwoWayバインディング出来てなかったのを修正

