### PR TITLE
仮想カメラ初使用のときのダイアログにTips導線を追加

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -126,6 +126,7 @@ Check "Keep LipSync" to make the lipsync continue.</sys:String>
 
 When you want to uninstall. double click "Uninstall.bat".</sys:String>        
     <sys:String x:Key="Window_VirtualCamOutput_FirstTime_OpenFolder">Open Folder</sys:String>
+    <sys:String x:Key="Window_VirtualCamOutput_FirstTime_SeeMore">Read more (on web)</sys:String>
     
     <!-- Motion -->
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -129,6 +129,7 @@
         
 アンインストールするには"Uninstall.bat"をダブルクリックで実行します。</sys:String>
     <sys:String x:Key="Window_VirtualCamOutput_FirstTime_OpenFolder">フォルダを開く</sys:String>
+    <sys:String x:Key="Window_VirtualCamOutput_FirstTime_SeeMore">さらに詳しく見る (webページへ)</sys:String>
     
     <!-- Motion -->
     

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/CameraInstallWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/CameraInstallWindow.xaml
@@ -6,13 +6,14 @@
         mc:Ignorable="d"
         Title="{DynamicResource Window_VirtualCamOutput_FirstTime_DialogTitle}" 
         Height="250" 
-        MinHeight="250"
+        MinHeight="280"
         Width="400"
         MinWidth="400"
         >
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="30"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -23,7 +24,16 @@
                    Margin="15"
                    TextWrapping="Wrap"
                    />
-        <Button Grid.Row="1"
+        <TextBlock Grid.Row="1"
+                   HorizontalAlignment="Right"
+                   TextAlignment="Right"
+                   Margin="15,0"
+                   TextWrapping="NoWrap">
+            <Hyperlink Command="{Binding OpenVirtualCamTipsCommand}">
+                <Run Text="{DynamicResource Window_VirtualCamOutput_FirstTime_SeeMore}"/>
+            </Hyperlink>
+        </TextBlock>
+        <Button Grid.Row="2"
                 Grid.Column="0"
                 Margin="20"
                 Width="150"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/CameraInstallerViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/CameraInstallerViewModel.cs
@@ -39,5 +39,18 @@ namespace Baku.VMagicMirrorConfig
                 MessageBox.Show(ex.Message + "\n" + ex.StackTrace, ex.GetType().Name, MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
+
+        private ActionCommand? _openVirtualCamTipsCommand;
+        public ActionCommand OpenVirtualCamTipsCommand
+            => _openVirtualCamTipsCommand ??= new ActionCommand(OpenVirtualCamTips);
+        private void OpenVirtualCamTips()
+        {
+            var url = LanguageSelector.StringToLanguage(LanguageSelector.Instance.LanguageName) switch
+            {
+                Languages.Japanese => "https://malaybaku.github.io/VMagicMirror/tips/virtual_camera",
+                _ => "https://malaybaku.github.io/VMagicMirror/en/tips/virtual_camera",
+            };
+            UrlNavigate.Open(url);
+        }
     }
 }


### PR DESCRIPTION
fixed https://github.com/malaybaku/VMagicMirror/issues/347 の半分

https://github.com/malaybaku/VMagicMirror/pull/385
でdocに「仮想カメラはVMM単体で会議したい時だけ使ってね、OBSある人にこの機能は要らないよ」と書いたので、それがちょっとでも目に付きやすいよう導線を足した。