### PR TITLE
常時手下げモード用のトグルを追加

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -70,6 +70,8 @@ namespace Baku.VMagicMirrorConfig
 
         #region モーション
 
+        public Message EnableNoHandTrackMode(bool enable) => WithArg($"{enable}");
+
         public Message LengthFromWristToTip(int lengthCentimeter) => WithArg($"{lengthCentimeter}");
 
         public Message LengthFromWristToPalm(int lengthCentimeter) => WithArg($"{lengthCentimeter}");

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -133,6 +133,11 @@ When you want to uninstall. double click "Uninstall.bat".</sys:String>
     
     <!-- Motion -->
     
+    <!-- Motion : Full Body -->
+    <sys:String x:Key="Motion_FullBody">Upper Body</sys:String>
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode">Always-Hands-Down Mode (*Increase body move)</sys:String>    
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">Hands-Down Mode</sys:String>    
+    
     <!-- Motion : Face -->
     <sys:String x:Key="Motion_Face">Face</sys:String>
     <sys:String x:Key="Motion_Face_EnableFaceTracking">Track Face</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -135,6 +135,11 @@
     
     <!-- Motion -->
     
+    <!-- Motion : Full Body -->
+    <sys:String x:Key="Motion_FullBody">上半身</sys:String>
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode">手の動きなしモード (※体の動きが増えます)</sys:String>    
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">手の動きなしモード</sys:String>    
+    
     <!-- Motion : Face -->
     <sys:String x:Key="Motion_Face">顔・表情</sys:String>
     <sys:String x:Key="Motion_Face_EnableFaceTracking">顔をトラッキング</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -137,8 +137,8 @@
     
     <!-- Motion : Full Body -->
     <sys:String x:Key="Motion_FullBody">上半身</sys:String>
-    <sys:String x:Key="Motion_FullBody_NoHandTrackMode">手の動きなしモード (※体の動きが増えます)</sys:String>    
-    <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">手の動きなしモード</sys:String>    
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode">つねに手下げモード (※体の動きが増えます)</sys:String>    
+    <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
     
     <!-- Motion : Face -->
     <sys:String x:Key="Motion_Face">顔・表情</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d" 
              d:DataContext="{x:Type vmm:MainWindowViewModel}"
              d:DesignWidth="520"
-             d:DesignHeight="620"
+             d:DesignHeight="570"
              >
     <UserControl.Resources>
         <vmm:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
@@ -33,7 +33,7 @@
         </Style>
             
         <Style TargetType="md:Card" BasedOn="{StaticResource {x:Type md:Card}}">
-            <Setter Property="Margin" Value="5"/>
+            <Setter Property="Margin" Value="4"/>
             <Setter Property="Padding" Value="5"/>
         </Style>
         <Style TargetType="md:PackIcon" x:Key="HeaderPackIcon">
@@ -59,7 +59,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   >
-        <Grid Margin="5">
+        <Grid Margin="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="300"/>
                 <ColumnDefinition Width="*"/>
@@ -114,7 +114,7 @@
                         </Grid>
 
                         <CheckBox IsChecked="{Binding WindowSetting.VirtualCamEnabled}" 
-                              Margin="5,5,5,0">
+                              Margin="5,3,5,0">
                             <TextBlock Text="{DynamicResource Window_VirtualCamOutput_Enable}"/>
                         </CheckBox>
 
@@ -168,7 +168,7 @@
                                         />
                         </StackPanel>
 
-                        <Grid Margin="5">
+                        <Grid Margin="5,3,5,5">
                             <Grid.RowDefinitions>
                                 <RowDefinition/>
                                 <RowDefinition/>
@@ -358,7 +358,7 @@
                                         />
                         </StackPanel>
 
-                        <Grid Margin="5">
+                        <Grid Margin="5,3">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="*"/>
@@ -614,7 +614,7 @@
                                   IsChecked="{Binding MotionSetting.EnablePresenterMotion}"
                                   />
 
-                        <CheckBox Margin="10,0,10,10"
+                        <CheckBox Margin="10,0,10,3"
                                   IsChecked="{Binding MotionSetting.EnableNoHandTrackMode}"                              >
                             <CheckBox.Content>
                                 <TextBlock Text="{DynamicResource Motion_FullBody_NoHandTrackMode_Streaming}"/>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
@@ -613,12 +613,18 @@
                                         />
                         </StackPanel>
 
-                        <CheckBox Grid.Row="2" Grid.Column="0"
-                                    Grid.ColumnSpan="3"
-                                    Margin="14,2,10,14" 
-                                    Content="{DynamicResource Motion_Arm_EnablePresenterMotion}"
-                                    IsChecked="{Binding MotionSetting.EnablePresenterMotion}"
-                                    />
+                        <CheckBox Margin="10,3,10,0" 
+                                  Content="{DynamicResource Motion_Arm_EnablePresenterMotion}"
+                                  IsChecked="{Binding MotionSetting.EnablePresenterMotion}"
+                                  />
+
+                        <CheckBox Margin="10,0,10,10"
+                                  IsChecked="{Binding MotionSetting.EnableNoHandTrackMode}"                              >
+                            <CheckBox.Content>
+                                <TextBlock Text="{DynamicResource Motion_FullBody_NoHandTrackMode_Streaming}"/>
+                            </CheckBox.Content>
+                        </CheckBox>
+
                     </StackPanel>
                 </md:Card>
             </StackPanel>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanelTabs/StreamingPanel.xaml
@@ -402,10 +402,6 @@
                                   Content="{DynamicResource Layout_Hid_Streaming}"
                                   />
                         <CheckBox Style="{StaticResource SmallMarginCheckBox}"
-                                  IsChecked="{Binding LayoutSetting.MidiControllerVisibility}"
-                                  Content="{DynamicResource Layout_Midi_Streaming}"
-                                  />
-                        <CheckBox Style="{StaticResource SmallMarginCheckBox}"
                                   Content="{DynamicResource Layout_Gamepad}"
                                   IsChecked="{Binding LayoutSetting.Gamepad.GamepadVisibility}"
                                   />

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -17,6 +17,32 @@
                   HorizontalScrollBarVisibility="Disabled"
                   >
         <StackPanel Margin="0,5">
+
+            <md:Card>
+                <StackPanel>
+
+                    <StackPanel Orientation="Horizontal"
+                                Margin="5"
+                                >
+                        <md:PackIcon Kind="HumanHandsdown"
+                                     Style="{StaticResource SettingHeaderPackIcon}"
+                                     />
+                        <TextBlock Text="{DynamicResource Motion_FullBody}"
+                                   Style="{StaticResource HeaderText}"
+                                   Margin="5"
+                                   />
+                    </StackPanel>
+
+                    <CheckBox Margin="15,0"
+                              IsChecked="{Binding EnableNoHandTrackMode}"
+                              >
+                        <CheckBox.Content>
+                            <TextBlock Text="{DynamicResource Motion_FullBody_NoHandTrackMode}"/>
+                        </CheckBox.Content>
+                    </CheckBox>
+                </StackPanel>
+            </md:Card>
+
             <md:Card>
                 <StackPanel>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/MainWindow.xaml
@@ -10,8 +10,8 @@
         d:DataContext="{x:Type vmm:MainWindowViewModel}"
         Title="VMagicMirror v1.3.0" 
         ResizeMode="CanMinimize"
-        Height="600" Width="550"
-        MinHeight="600" MinWidth="550"
+        Height="650" Width="550"
+        MinHeight="650" MinWidth="550"
         Icon="../../Images/vmmc_logo.png"
         >
     <Window.DataContext>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -123,6 +123,23 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
+        #region Full Body 
+
+        private bool _enableNoHandTrackMode = false;
+        public bool EnableNoHandTrackMode
+        {
+            get => _enableNoHandTrackMode;
+            set
+            {
+                if (SetValue(ref _enableNoHandTrackMode, value))
+                {
+                    SendMessage(MessageFactory.Instance.EnableNoHandTrackMode(EnableNoHandTrackMode));
+                }
+            }
+        }
+
+        #endregion
+
         #region Face
 
         private bool _enableFaceTracking = true;
@@ -838,6 +855,7 @@ namespace Baku.VMagicMirrorConfig
 
         public override void ResetToDefault()
         {
+            EnableNoHandTrackMode = false;
             ResetFaceSetting();
             ResetArmSetting();
             ResetHandSetting();


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/375

コレに伴い、

- 「配信」タブから、使用頻度が低いハズのMIDIコンの表示/非表示オプションを外しました。
- この機能はタブスクロールせずに目に入るのが望ましいため、メインウィンドウの縦幅をちょっと増やしたりマージンを調整したりして、デフォルト状態ではスクロールしないようにしました。
