### PR TITLE
「手首から手先までの長さ」の下限を1cmではなく0cmに変更

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -87,7 +87,6 @@ namespace Baku.VMagicMirrorConfig
 
         public Message EnableFpsAssumedRightHand(bool enable) => WithArg($"{enable}");
         public Message EnablePresenterMotion(bool enable) => WithArg($"{enable}");
-        public Message PresentationArmMotionScale(int scalePercent) => WithArg($"{scalePercent}");
         public Message PresentationArmRadiusMin(int radiusMinCentimeter) => WithArg($"{radiusMinCentimeter}");
 
         public Message EnableWaitMotion(bool enable) => WithArg($"{enable}");

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -74,8 +74,6 @@ namespace Baku.VMagicMirrorConfig
 
         public Message LengthFromWristToTip(int lengthCentimeter) => WithArg($"{lengthCentimeter}");
 
-        public Message LengthFromWristToPalm(int lengthCentimeter) => WithArg($"{lengthCentimeter}");
-
         public Message HandYOffsetBasic(int offsetCentimeter) => WithArg($"{offsetCentimeter}");
         public Message HandYOffsetAfterKeyDown(int offsetCentimeter) => WithArg($"{offsetCentimeter}");
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d"
              d:DataContext="{x:Type vmm:MotionSettingViewModel}"
              d:DesignWidth="400"
-             d:DesignHeight="1350"
+             d:DesignHeight="2850"
              >
     <UserControl.Resources>
         <vmm:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
@@ -581,7 +581,7 @@
                                    Text="{DynamicResource Motion_Hand_WristToHandTip}"/>
                         <Slider Grid.Row="0" Grid.Column="1"
                                 x:Name="sliderWristToTip"
-                                Minimum="1"
+                                Minimum="0"
                                 Maximum="50"
                                 Value="{Binding LengthFromWristToTip, Mode=TwoWay}"
                                 />
@@ -593,7 +593,7 @@
                                    Text="{DynamicResource Motion_Hand_WristToPalm}"/>
                         <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderWristToPalm"
-                                Minimum="1"
+                                Minimum="0"
                                 Maximum="50"
                                 Value="{Binding LengthFromWristToPalm, Mode=TwoWay}"
                                 />

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -575,18 +575,6 @@
                                  Text="{Binding Value, ElementName=sliderWristToTip}"
                                  />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0"
-                                   Text="{DynamicResource Motion_Hand_WristToPalm}"/>
-                        <Slider Grid.Row="1" Grid.Column="1"
-                                x:Name="sliderWristToPalm"
-                                Minimum="0"
-                                Maximum="50"
-                                Value="{Binding LengthFromWristToPalm, Mode=TwoWay}"
-                                />
-                        <TextBox Grid.Row="1" Grid.Column="2"
-                                 Text="{Binding Value, ElementName=sliderWristToPalm}"
-                                 />
-
                         <TextBlock Grid.Row="2" Grid.Column="0"
                                    Text="{DynamicResource Motion_Hand_HandYOffsetBasic}"/>
                         <Slider Grid.Row="2" Grid.Column="1"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -512,21 +512,7 @@
                                   Content="{DynamicResource Motion_Arm_ShowPresentationPointer}"
                                   IsChecked="{Binding ShowPresentationPointer}"
                                   />
-                        
-                        <TextBlock Grid.Row="5" Grid.Column="0"
-                                   Margin="15,0,0,0"
-                                   Text="{DynamicResource Motion_Arm_PresenterArmMotionScale}"/>
-                        <Slider Grid.Row="5" Grid.Column="1"
-                                x:Name="sliderPresentationArmMotionScale"
-                                Minimum="1"
-                                Maximum="100"
-                                IsEnabled="{Binding EnablePresenterMotion}"
-                                Value="{Binding PresentationArmMotionScale, Mode=TwoWay}"
-                                />
-                        <TextBox Grid.Row="5" Grid.Column="2"
-                                 IsEnabled="{Binding EnablePresenterMotion}"
-                                 Text="{Binding Value, ElementName=sliderPresentationArmMotionScale}"
-                                 />
+                       
                         <TextBlock Grid.Row="6" Grid.Column="0"
                                    Margin="15,0,0,0"
                                    Text="{DynamicResource Motion_Arm_PresenterArmRadiusMin}"/>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -109,7 +109,6 @@ namespace Baku.VMagicMirrorConfig
 
                 if (!onlyEyebrow)
                 {
-                    LengthFromWristToPalm = parameters.LengthFromWristToPalm;
                     LengthFromWristToTip = parameters.LengthFromWristToTip;
                 }
             }
@@ -669,20 +668,6 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
-        private int _lengthFromWristToPalm = 6;
-        /// <summary> Unit: [cm] </summary>
-        public int LengthFromWristToPalm
-        {
-            get => _lengthFromWristToPalm;
-            set
-            {
-                if (SetValue(ref _lengthFromWristToPalm, value))
-                {
-                    SendMessage(MessageFactory.Instance.LengthFromWristToPalm(LengthFromWristToPalm));
-                }
-            }
-        }
-
         private int _handYOffsetBasic = 3;
         public int HandYOffsetBasic
         {
@@ -827,7 +812,6 @@ namespace Baku.VMagicMirrorConfig
         private void ResetHandSetting()
         {
             LengthFromWristToTip = 12;
-            LengthFromWristToPalm = 6;
             HandYOffsetBasic = 3;
             HandYOffsetAfterKeyDown = 2;
         }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MotionSettingViewModel.cs
@@ -638,19 +638,6 @@ namespace Baku.VMagicMirrorConfig
                 );
         }
 
-        private int _presentationArmMotionScale = 50;
-        public int PresentationArmMotionScale
-        {
-            get => _presentationArmMotionScale;
-            set
-            {
-                if (SetValue(ref _presentationArmMotionScale, value))
-                {
-                    SendMessage(MessageFactory.Instance.PresentationArmMotionScale(PresentationArmMotionScale));
-                }
-            }
-        }
-
         private int _presentationArmRadiusMin = 20;
         public int PresentationArmRadiusMin
         {
@@ -834,7 +821,6 @@ namespace Baku.VMagicMirrorConfig
             EnableFpsAssumedRightHand = false;
             EnablePresenterMotion = false;
             ShowPresentationPointer = false;
-            PresentationArmMotionScale = 30;
             PresentationArmRadiusMin = 20;
         }
 


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/406

- マイナスはやっぱりちょっとなあ…と思ったのでゼロ下限にしてます
- このPRで同時に「プレゼン動作スケール」「手から手のひら中央までの距離」の2パラメータは削除しています(Unity側で使ってなかったパラメータであったため)
