### PR TITLE
カスタムモーション再生用のUI追加

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -234,6 +234,14 @@ namespace Baku.VMagicMirrorConfig
         public Message LoadMidiNoteToMotionMap(string content) => WithArg(content);
         public Message RequireMidiNoteOnMessage(bool require) => WithArg($"{require}");
 
+        public Message RequestCustomMotionDoctor() => NoArg();
+
+        /// <summary>
+        /// Query 
+        /// </summary>
+        /// <returns></returns>
+        public Message GetAvailableCustomClipNames() => NoArg();
+
         #endregion
 
         #region External Tracker

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/InterprocessCommunication/MessageFactory.cs
@@ -240,7 +240,7 @@ namespace Baku.VMagicMirrorConfig
         /// Query 
         /// </summary>
         /// <returns></returns>
-        public Message GetAvailableCustomClipNames() => NoArg();
+        public Message GetAvailableCustomMotionClipNames() => NoArg();
 
         #endregion
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecificMessageData/MotionRequest.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SpecificMessageData/MotionRequest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 
@@ -8,12 +7,12 @@ namespace Baku.VMagicMirrorConfig
 {
     //NOTE: Unity側のMotionRequestとプロパティ名を統一してます。片方だけいじらないように！
 
-    /// <summary>単一のBVHまたはビルトインモーション、および表情制御のリクエスト情報を表す。</summary>
+    /// <summary>ビルトインモーションまたはカスタムモーション、および表情制御のリクエスト情報を表す。</summary>
     public class MotionRequest
     {
         public const int MotionTypeNone = 0;
         public const int MotionTypeBuiltInClip = 1;
-        public const int MotionTypeBvhFile = 2;
+        public const int MotionTypeCustom = 2;
 
         public int MotionType { get; set; }
 
@@ -21,7 +20,7 @@ namespace Baku.VMagicMirrorConfig
 
         public string BuiltInAnimationClipName { get; set; } = "";
 
-        public string ExternalBvhFilePath { get; set; } = "";
+        public string CustomMotionClipName { get; set; } = "";
 
         public float DurationWhenOnlyBlendShape { get; set; } = 3.0f;
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -328,11 +328,13 @@ Please test by typing "joy".</sys:String>
     <sys:String x:Key="WordToMotion_BodyMotion_Header">Body Motion</sys:String>
     <sys:String x:Key="WordToMotion_MotionType_None">None</sys:String>
     <sys:String x:Key="WordToMotion_MotionType_BuiltIn">Built-In Motion</sys:String>
-    <sys:String x:Key="WordToMotion_MotionType_BvhFile">BVH File</sys:String>
+    <sys:String x:Key="WordToMotion_MotionType_Custom">Custom Motion</sys:String>
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Label">Motion</sys:String>
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Hint">Choose Motion</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_BvhFile_Label">File</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_BvhFile_Hint">File Path</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_Label">Motion</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_Hint">Choose Motion</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">How to Use (open web)</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_Doctor">Check Motion Data Validity</sys:String>
 
     <sys:String x:Key="WordToMotion_Face_Header">Face Expression</sys:String>
     <sys:String x:Key="WordToMotion_Face_Enable">Enable Face Expression</sys:String>
@@ -352,5 +354,7 @@ Please test by typing "joy".</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_Current">Current Note</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_After">Note to Change</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_Clear">Clear</sys:String>
+    
+
 
 </ResourceDictionary>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -330,11 +330,15 @@
     <sys:String x:Key="WordToMotion_BodyMotion_Header">全身モーション</sys:String>
     <sys:String x:Key="WordToMotion_MotionType_None">なし</sys:String>
     <sys:String x:Key="WordToMotion_MotionType_BuiltIn">ビルトインモーション</sys:String>
-    <sys:String x:Key="WordToMotion_MotionType_BvhFile">BVHファイル</sys:String>
+    <sys:String x:Key="WordToMotion_MotionType_Custom">カスタムモーション</sys:String>
+    
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Label">モーション</sys:String>
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Hint">モーションを選択</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_BvhFile_Label">ファイル</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_BvhFile_Hint">File Path</sys:String>
+    
+    <sys:String x:Key="WordToMotion_Motion_Custom_Label">モーション</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_Hint">モーションを選択</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">使い方 (Webページを開きます)</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_Doctor">モーションデータを診断</sys:String>
 
     <sys:String x:Key="WordToMotion_Face_Header">表情</sys:String>
     <sys:String x:Key="WordToMotion_Face_Enable">表情の動作を有効化</sys:String>
@@ -354,5 +358,5 @@
     <sys:String x:Key="WordToMotion_MidiAssign_Current">現在のノート</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_After">変更後のノート</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_Clear">クリア</sys:String>
-    
+   
 </ResourceDictionary>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/SettingWindow.xaml
@@ -151,11 +151,11 @@
                     Background="{Binding SelectedIndex,
                                         ElementName=MainTabControl,
                                         Converter={StaticResource SelectionToBackground},
-                                        ConverterParameter=2}"
+                                        ConverterParameter=4}"
                     Foreground="{Binding SelectedIndex,
                                         ElementName=MainTabControl,
                                         Converter={StaticResource SelectionToForeground},
-                                        ConverterParameter=2}"                        
+                                        ConverterParameter=4}"                        
                     />
             </TabItem.Header>
             <vmm:DeviceSettingPanel 
@@ -171,11 +171,11 @@
                     Background="{Binding SelectedIndex,
                                         ElementName=MainTabControl,
                                         Converter={StaticResource SelectionToBackground},
-                                        ConverterParameter=4}"
+                                        ConverterParameter=5}"
                     Foreground="{Binding SelectedIndex,
                                         ElementName=MainTabControl,
                                         Converter={StaticResource SelectionToForeground},
-                                        ConverterParameter=4}">
+                                        ConverterParameter=5}">
                         
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
@@ -105,38 +105,35 @@
                 </DockPanel>
 
 
-                <!--<RadioButton Content="{DynamicResource WordToMotion_MotionType_BvhFile}"
+                <RadioButton Content="{DynamicResource WordToMotion_MotionType_Custom}"
                              Margin="0,20,0,5"
                              VerticalContentAlignment="Center"
-                             IsChecked="{Binding IsMotionTypeBvhFile}"
+                             IsChecked="{Binding IsMotionTypeCustom}"
                              />
-                <DockPanel Margin="5"
-                           LastChildFill="True"
-                           >
-                    <TextBlock DockPanel.Dock="Left"
-                               Text="{DynamicResource WordToMotion_Motion_BvhFile_Label}"
-                               />
+                                
+                <DockPanel LastChildFill="True"
+                           Margin="5">
+                    <TextBlock Text="{DynamicResource WordToMotion_Motion_Custom_Label}" />
+                    <ComboBox ItemsSource="{Binding AvailableCustomMotionClipNames}"
+                              SelectedItem="{Binding CustomMotionClipName}"
+                              IsEnabled="{Binding IsMotionTypeCustomClip}"
+                              Margin="10,0"
+                              md:HintAssist.Hint="{DynamicResource WordToMotion_Motion_Custom_Hint}"
+                              />
+                </DockPanel>
 
-                    <Button DockPanel.Dock="Right"
-                            Style="{StaticResource MaterialDesignRaisedLightButton}"
-                            Content="..."
-                            Width="30"
-                            Height="25"
-                            Padding="0"
-                            Margin="0"
-                            Command="{Binding SelectBvhFileCommand}"
-                            IsEnabled="{Binding IsMotionTypeBvhFile}"
-                            />
-
-
-                    <TextBox Margin="5,0"
-                             Text="{Binding BvhFilePath}"
-                             IsEnabled="{Binding IsMotionTypeBvhFile}"
-                             md:HintAssist.Hint="{DynamicResource WordToMotion_Motion_BvhFile_Hint}"
-                             />
-
-                </DockPanel>-->
-
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                        Content="{DynamicResource WordToMotion_Motion_Custom_HowTo}"
+                        Command="{Binding OpenWordToMotionCustomHowToCommand}"
+                        Margin="10,0"
+                        Width="NaN"
+                        HorizontalAlignment="Left"
+                        />
+                <Button Style="{StaticResource MaterialDesignRaisedButton}"
+                        Content="{DynamicResource WordToMotion_Motion_Custom_Doctor}"
+                        Command="{Binding CheckCustomMotionDataValidityCommand}"
+                        Margin="10,5"
+                        />
             </StackPanel>
         </Border>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
@@ -129,11 +129,12 @@
                         Width="NaN"
                         HorizontalAlignment="Left"
                         />
-                <Button Style="{StaticResource MaterialDesignRaisedButton}"
+                <!-- 診断機能を検討してIPCまではも用意したものの、まだ仕組みがきちんとしてないので一旦隠します -->
+                <!--<Button Style="{StaticResource MaterialDesignRaisedButton}"
                         Content="{DynamicResource WordToMotion_Motion_Custom_Doctor}"
                         Command="{Binding CheckCustomMotionDataValidityCommand}"
                         Margin="10,5"
-                        />
+                        />-->
             </StackPanel>
         </Border>
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -403,6 +403,7 @@ namespace Baku.VMagicMirrorConfig
 
             await MotionSetting.InitializeDeviceNamesAsync();
             await LightSetting.InitializeQualitySelectionsAsync();
+            await WordToMotionSetting.InitializeCustomMotionClipNamesAsync();
 
             Initializer.CameraPositionChecker.Start(
                 2000,

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionItemViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionItemViewModel.cs
@@ -28,6 +28,8 @@ namespace Baku.VMagicMirrorConfig
 
         private readonly WordToMotionSettingViewModel _parent;
 
+        public ReadOnlyObservableCollection<string> AvailableCustomMotionClipNames => _parent.CustomMotionClipNames;
+
         /// <summary>ファイルI/Oや通信のベースになるデータを取得します。</summary>
         public MotionRequest? MotionRequest { get; }
 
@@ -126,7 +128,7 @@ namespace Baku.VMagicMirrorConfig
             {
                 return IsMotionTypeNone ? MotionRequest.MotionTypeNone :
                     IsMotionTypeBuiltInClip ? MotionRequest.MotionTypeBuiltInClip :
-                    IsMotionTypeBvhFile ? MotionRequest.MotionTypeBvhFile :
+                    IsMotionTypeCustom ? MotionRequest.MotionTypeCustom :
                     MotionRequest.MotionTypeNone;
             }
         }
@@ -142,7 +144,7 @@ namespace Baku.VMagicMirrorConfig
                 if (value)
                 {
                     IsMotionTypeBuiltInClip = false;
-                    IsMotionTypeBvhFile = false;
+                    IsMotionTypeCustom = false;
                 }
                 _isMotionTypeNone = value;
                 RaisePropertyChanged();
@@ -160,26 +162,26 @@ namespace Baku.VMagicMirrorConfig
                 if (value)
                 {
                     IsMotionTypeNone = false;
-                    IsMotionTypeBvhFile = false;
+                    IsMotionTypeCustom = false;
                 }
                 _isMotionTypeBuiltInClip = value;
                 RaisePropertyChanged();
             }
         }
 
-        private bool _isMotionTypeBvhFile = false;
-        public bool IsMotionTypeBvhFile
+        private bool _isMotionTypeCustom = false;
+        public bool IsMotionTypeCustom
         {
-            get => _isMotionTypeBvhFile;
+            get => _isMotionTypeCustom;
             set
             {
-                if (_isMotionTypeBvhFile == value) { return; }
+                if (_isMotionTypeCustom == value) { return; }
                 if (value)
                 {
                     IsMotionTypeNone = false;
                     IsMotionTypeBuiltInClip = false;
                 }
-                _isMotionTypeBvhFile = value;
+                _isMotionTypeCustom = value;
                 RaisePropertyChanged();
             }
         }
@@ -191,11 +193,11 @@ namespace Baku.VMagicMirrorConfig
             set => SetValue(ref _builtInClipName, value);
         }
 
-        private string _bvhFilePath = "";
-        public string BvhFilePath
+        private string _customMotionClipName = "";
+        public string CustomMotionClipName
         {
-            get => _bvhFilePath;
-            set => SetValue(ref _bvhFilePath, value);
+            get => _customMotionClipName;
+            set => SetValue(ref _customMotionClipName, value);
         }
 
         private bool _useBlendShape = false;
@@ -238,23 +240,6 @@ namespace Baku.VMagicMirrorConfig
 
         #region Commands
 
-        private ActionCommand? _selectBvhFileCommand;
-        public ActionCommand SelectBvhFileCommand
-            => _selectBvhFileCommand ??= new ActionCommand(SelectBvhFile);
-        private void SelectBvhFile()
-        {
-            var dialog = new OpenFileDialog()
-            {
-                Title = "Select Motion File",
-                Filter = "BVH file(*.bvh)|*.bvh",
-                Multiselect = false,
-            };
-            if (dialog.ShowDialog() == true)
-            {
-                BvhFilePath = System.IO.Path.GetFullPath(dialog.FileName);
-            }
-        }
-
         private ActionCommand? _moveUpCommand;
         public ActionCommand MoveUpCommand
             => _moveUpCommand ??= new ActionCommand(() => _parent.MoveUpItem(this));
@@ -275,6 +260,18 @@ namespace Baku.VMagicMirrorConfig
         public ActionCommand DeleteCommand
             => _deleteCommand ??= new ActionCommand(async () => await _parent.DeleteItem(this));
 
+        private ActionCommand? _openWordToMotionCustomHowToCommand;
+        public ActionCommand OpenWordToMotionCustomHowToCommand
+            => _openWordToMotionCustomHowToCommand ??= new ActionCommand(() => UrlNavigate.Open(
+                "https://malaybaku.github.io/VMagicMirror/docs/expressions_custom_motion"
+                ));
+
+        private ActionCommand? _checkCustomMotionDataValidityCommand;
+        public ActionCommand CheckCustomMotionDataValidityCommand
+            => _checkCustomMotionDataValidityCommand ??= new ActionCommand(
+                () => _parent.RequestCustomMotionDoctor()
+                );
+
         #endregion
 
         private ObservableCollection<string> _availableBuiltInClipNames
@@ -294,7 +291,7 @@ namespace Baku.VMagicMirrorConfig
             model.MotionType = MotionType;
 
             model.BuiltInAnimationClipName = BuiltInClipName;
-            model.ExternalBvhFilePath = BvhFilePath;
+            model.CustomMotionClipName = CustomMotionClipName;
             model.UseBlendShape = UseBlendShape;
             model.HoldBlendShape = HoldBlendShape;
             model.PreferLipSync = PreferLipSync;
@@ -332,8 +329,8 @@ namespace Baku.VMagicMirrorConfig
                 case MotionRequest.MotionTypeBuiltInClip:
                     IsMotionTypeBuiltInClip = true;
                     break;
-                case MotionRequest.MotionTypeBvhFile:
-                    IsMotionTypeBvhFile = true;
+                case MotionRequest.MotionTypeCustom:
+                    IsMotionTypeCustom = true;
                     break;
                 default:
                     IsMotionTypeNone = true;
@@ -341,7 +338,7 @@ namespace Baku.VMagicMirrorConfig
             }
 
             BuiltInClipName = model.BuiltInAnimationClipName;
-            BvhFilePath = model.ExternalBvhFilePath;
+            CustomMotionClipName = model.CustomMotionClipName;
 
             UseBlendShape = model.UseBlendShape;
             HoldBlendShape = model.HoldBlendShape;
@@ -366,7 +363,6 @@ namespace Baku.VMagicMirrorConfig
                 }
             }
         }
-
 
         private void InitializeBuiltInClipNames()
         {

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
@@ -93,7 +93,7 @@ namespace Baku.VMagicMirrorConfig
 
         public async Task InitializeCustomMotionClipNamesAsync()
         {
-            var rawClipNames = await SendQueryAsync(MessageFactory.Instance.GetAvailableCustomClipNames());
+            var rawClipNames = await SendQueryAsync(MessageFactory.Instance.GetAvailableCustomMotionClipNames());
             var clipNames = rawClipNames.Split('\t');
             foreach(var name in clipNames)
             {

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/WordToMotionSettingViewModel.cs
@@ -26,6 +26,8 @@ namespace Baku.VMagicMirrorConfig
         internal WordToMotionSettingViewModel(IMessageSender sender, IMessageReceiver receiver) : base(sender)
         {
             Items = new ReadOnlyObservableCollection<WordToMotionItemViewModel>(_items);
+            CustomMotionClipNames = new ReadOnlyObservableCollection<string>(_customMotionClipNames);
+
             Devices = WordToMotionDeviceItem.LoadAvailableItems();
             SelectedDevice = Devices.FirstOrDefault(d => d.Index == DeviceTypeKeyboardWord);
             _previewDataSender = new WordToMotionItemPreviewDataSender(sender);
@@ -89,6 +91,19 @@ namespace Baku.VMagicMirrorConfig
             }
         }
 
+        public async Task InitializeCustomMotionClipNamesAsync()
+        {
+            var rawClipNames = await SendQueryAsync(MessageFactory.Instance.GetAvailableCustomClipNames());
+            var clipNames = rawClipNames.Split('\t');
+            foreach(var name in clipNames)
+            {
+                _customMotionClipNames.Add(name);
+            }
+        }
+
+        private readonly ObservableCollection<string> _customMotionClipNames = new ObservableCollection<string>();
+        [XmlIgnore]
+        public ReadOnlyObservableCollection<string> CustomMotionClipNames { get; }
 
         private bool _enableWordToMotion = true;
         [XmlIgnore]
@@ -471,6 +486,9 @@ namespace Baku.VMagicMirrorConfig
             EnablePreview = false;
             _dialogItem = null;
         }
+
+        public void RequestCustomMotionDoctor()
+            => SendMessage(MessageFactory.Instance.RequestCustomMotionDoctor());
     }
 
 


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/408

※ついでに https://github.com/malaybaku/VMagicMirror/issues/482 も直ってます

UI的に増えてるもの

- Word to Motionの選択欄に「カスタム」が増え、Unity側から利用可能なモーション名を受け取って一覧表示できるようになりました

UI的にやろうと思ったけどやってないこと

- データ診断機能: いい感じに動かすのが難しいため断念。代替策として「アプリ起動時にUnity側がLogOutputを使ってカスタムモーションの読み込み結果を出力する」みたいな事は仕込んでおく予定。
