### PR TITLE
Localization Support

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/LanguageSelector.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/LanguageSelector.cs
@@ -54,23 +54,7 @@ namespace Baku.VMagicMirrorConfig
         {
             _sender = sender;
             _dictionaryLoader.LoadFromDefaultLocation();
-        }
-
-        public void InitializePreferredLanguage(string preferredLanguageName)
-        {
-            if (preferredLanguageName == "Japanese" || 
-                preferredLanguageName == "English")
-            {
-                LanguageName = preferredLanguageName;
-            }
-            else
-            {
-                //NOTE: 普通はここには来ない
-                LanguageName =
-                    (CultureInfo.CurrentCulture.Name == "ja-JP") ?
-                    "Japanese" :
-                    "English";
-            }
+            ApplyFallbackLocalize();
         }
 
         private bool IsValidLanguageName(string languageName)
@@ -97,6 +81,37 @@ namespace Baku.VMagicMirrorConfig
 
             Application.Current.Resources.MergedDictionaries[0] = dict;
             _sender?.SendMessage(MessageFactory.Instance.Language(languageName));
+        }
+
+        /// <summary>
+        /// 日英以外のローカライズファイルでキーが漏れている場合に英語で補填する処理
+        /// </summary>
+        private void ApplyFallbackLocalize()
+        {
+            var englishDict = new ResourceDictionary()
+            {
+                Source = new Uri($"/VMagicMirrorConfig;component/Resources/English.xaml", UriKind.Relative),
+            };
+            var englishDictKeys = englishDict.Keys.Cast<string>().ToHashSet();
+
+            foreach (var pair in _dictionaryLoader.GetLoadedDictionaries())
+            {
+                bool missingKeyFound = false;
+                var d = pair.Value;
+                var targetKeys = d.Keys.Cast<string>().ToHashSet();
+                //NOTE: このExceptが重い気がするが、リソースディクショナリの仕様上こうするしかなさそうなので頑張らないでおく
+                foreach (var fallbackKey in englishDictKeys.Except(targetKeys))
+                {
+                    d[fallbackKey] = englishDict[fallbackKey];
+
+                    //全部指摘してもくどいので、各言語についてローカライズ漏れは最大1箇所だけの指摘に留める
+                    if (!missingKeyFound)
+                    {
+                        missingKeyFound = true;
+                        LogOutput.Instance.Write($"Localization '{pair.Key}' does not have key '{fallbackKey}'.");
+                    }
+                }
+            }
         }
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/LocalizationDictionaryLoader.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Localization/LocalizationDictionaryLoader.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+using System.Xaml;
+
+namespace Baku.VMagicMirrorConfig
+{
+    /// <summary>
+    /// JP/EN以外の翻訳テキストがある場合にそれをResourceDictionaryとしてロードできるやつ
+    /// </summary>
+    class LocalizationDictionaryLoader
+    {
+        private readonly Dictionary<string, ResourceDictionary> _dictionaries
+            = new Dictionary<string, ResourceDictionary>();
+
+        public void LoadFromDefaultLocation()
+        {
+            _dictionaries.Clear();
+
+            var exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (exeDir == null)
+            {
+                return;
+            }
+
+            var searchDir = Path.Combine(exeDir, "Localization");
+            if (!Directory.Exists(searchDir))
+            {
+                return;
+            }
+
+            foreach (var filePath in Directory.GetFiles(searchDir))
+            {
+                var key = Path.GetFileNameWithoutExtension(filePath);
+                if (key == LanguageSelector.LangNameJapanese || key == LanguageSelector.LangNameEnglish)
+                {
+                    LogOutput.Instance.Write("Localization file for Japanese and English is ignored");
+                    continue;
+                }
+
+                try
+                {
+                    var reader = new XamlXmlReader(filePath);
+                    var dict = XamlServices.Load(reader) as ResourceDictionary;
+                    if (dict != null)
+                    {
+                        
+                        _dictionaries[key] = dict;
+                        LogOutput.Instance.Write("Localization file loaded: " + key);
+                    }
+                    else
+                    {
+                        LogOutput.Instance.Write("Load seems success, but Resource Dictionary was not loaded actually." + filePath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LogOutput.Instance.Write(ex);
+                }
+            }
+        }
+
+        public Dictionary<string, ResourceDictionary> GetLoadedDictionaries() => _dictionaries;
+
+    }
+}

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SettingSync/RootSettingSync.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SettingSync/RootSettingSync.cs
@@ -29,7 +29,6 @@ namespace Baku.VMagicMirrorConfig
             {
                 LanguageSelector.Instance.LanguageName = s;
             });
-
         }
 
         private readonly IMessageSender _sender;
@@ -37,8 +36,8 @@ namespace Baku.VMagicMirrorConfig
         private readonly ObservableCollection<string> _availableLanguageNames
             = new ObservableCollection<string>()
         {
-            "Japanese",
-            "English",
+            LanguageSelector.LangNameJapanese,
+            LanguageSelector.LangNameEnglish,
         };
         public ReadOnlyObservableCollection<string> AvailableLanguageNames { get; }
 
@@ -66,6 +65,14 @@ namespace Baku.VMagicMirrorConfig
 
         public ExternalTrackerSettingSync ExternalTracker { get; }
 
+        public void InitializeAvailableLanguage(string[] languageNames)
+        {
+            foreach(var name in languageNames)
+            {
+                _availableLanguageNames.Add(name);
+            }
+        }
+
         /// <summary>
         /// 自動保存される設定ファイルに言語設定が保存されていなかった場合、
         /// 現在のカルチャに応じた初期言語を設定します。
@@ -76,8 +83,8 @@ namespace Baku.VMagicMirrorConfig
             {
                 LanguageName.Value =
                     (CultureInfo.CurrentCulture.Name == "ja-JP") ?
-                    "Japanese" :
-                    "English";
+                    LanguageSelector.LangNameJapanese :
+                    LanguageSelector.LangNameEnglish;
             }
         }
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/English.xaml
@@ -45,12 +45,9 @@
     <sys:String x:Key="Home_SettingManagement">Setting Management</sys:String>
     <sys:String x:Key="Home_Reset">Reset</sys:String>
     <sys:String x:Key="Home_LoadPrevSetting">Load from Prev ver.</sys:String>
-
-    <sys:String x:Key="Home_OssLicense">OSS License</sys:String>
     
     <sys:String x:Key="Home_OtherSettings_Header">Other Preferences</sys:String>
     <sys:String x:Key="Home_ActivateOnStartupHeader">Start on Windows startup</sys:String>
-    <sys:String x:Key="Home_ActivateOnStartup_OtherVerRegistered">*Other version VMagicMirror is already registered. If you check it, setting will be overwritten to start this version.</sys:String>
     
     <!-- Streaming -->
     <sys:String x:Key="Streaming_Window">Window</sys:String>
@@ -58,10 +55,11 @@
     <sys:String x:Key="Streaming_Motion">Motion</sys:String>       
     <sys:String x:Key="Streaming_WordToMotion">Word to Motion</sys:String>
     <sys:String x:Key="Streaming_View">View</sys:String>
+    
     <sys:String x:Key="Streaming_DeviceLayout">Device Layout</sys:String>
     <sys:String x:Key="Streaming_DeviceLayout_Reset">Reset</sys:String>
+
     <sys:String x:Key="Streaming_Screenshot">Screenshot</sys:String>
-    <sys:String x:Key="Streaming_Screenshot_Take">Take</sys:String>
     <sys:String x:Key="Streaming_Screenshot_OpenSaveFolder">Saved Folder...</sys:String>
     
      <!-- Ex.Tracker -->
@@ -87,7 +85,6 @@ During this mode, following features are disabled.
     <sys:String x:Key="ExTracker_Source_iFacialMocap">iFacialMocap</sys:String>
     <sys:String x:Key="ExTracker_iFM_IpHint">iPhone IP Address...</sys:String>
     <sys:String x:Key="ExTracker_Source_HowToCollaborate">*See how to connect (open web page)</sys:String>
-    <sys:String x:Key="ExTracker_Source_RefreshReceiverSetting">Check network setting again</sys:String>
 
     <sys:String x:Key="ExTracker_iFM_HasTrouble_Header">Please check connected app setting</sys:String>
     <sys:String x:Key="ExTracker_iFM_HasTrouble_OpenUrl">Open Troubleshoot web page</sys:String>    
@@ -123,12 +120,6 @@ Check "Keep LipSync" to make the lipsync continue.</sys:String>
     <sys:String x:Key="Window_BackgroundImage_Load">Load...</sys:String>
     <sys:String x:Key="Window_BackgroundImage_Clear">Clear</sys:String>
 
-    <sys:String x:Key="Window_EnableInitialPlacement">Move window to specific position on startup</sys:String>
-    <sys:String x:Key="Window_InitialPositionX">X(Left = 0)</sys:String>
-    <sys:String x:Key="Window_InitialPositionY">Y(Top = 0)</sys:String>
-    <sys:String x:Key="Window_FetchUnityWindowPos">Check current window position</sys:String>
-    <sys:String x:Key="Window_MoveWindow">Move to specified position</sys:String>
-
     <sys:String x:Key="Window_TransparencySupport">Character Transparency Support</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level">Transparency Level</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Alpha">Alpha when Transparent(32-255)</sys:String>
@@ -160,14 +151,11 @@ Check "Keep LipSync" to make the lipsync continue.</sys:String>
     <sys:String x:Key="Motion_Arm_ElbowCloseStrength">Strength to keep upper arm to body [%]</sys:String>
     <sys:String x:Key="Motion_Arm_EnablePresenterMotion">Presentation-like hand</sys:String>
     <sys:String x:Key="Motion_Arm_ShowPresentationPointer">Show Pointer Support</sys:String>
-    <sys:String x:Key="Motion_Arm_PresenterArmMotionScale">Presentation-like motion scale [%]</sys:String>
     <sys:String x:Key="Motion_Arm_PresenterArmRadiusMin">Arm position radius min [cm]</sys:String>
 
     <!-- Motion : Hand -->
     <sys:String x:Key="Motion_Hand">Hand</sys:String>
-    <sys:String x:Key="Motion_Hand_CharacterHandMotion">Hand Motion</sys:String>
     <sys:String x:Key="Motion_Hand_WristToHandTip">Wrist-Hand tip length [cm]</sys:String>
-    <sys:String x:Key="Motion_Hand_WristToPalm">Wrist-Palm length [cm]</sys:String>
     <sys:String x:Key="Motion_Hand_HandYOffsetBasic">Hand height adjust [cm]</sys:String>
     <sys:String x:Key="Motion_Hand_HandYOffsetAfterKeyDown">(Press key)Hand height adjust [cm]</sys:String>
 
@@ -179,7 +167,16 @@ Check "Keep LipSync" to make the lipsync continue.</sys:String>
     
     <!-- Face -->
     <sys:String x:Key="Motion_Face">Face</sys:String>
+
+    <!-- Face : Basic -->
     <sys:String x:Key="Motion_Face_Basics">Basic Settings</sys:String>
+    
+    <sys:String x:Key="Motion_Mouth">Mouth</sys:String>
+    <sys:String x:Key="Motion_Mouth_EnableLipSync">LipSync</sys:String>
+    <sys:String x:Key="Motion_Mouth_MicrophoneName">Microphone</sys:String>    
+    <sys:String x:Key="Motion_Mouth_Microphone_Sensitivity">Sensitivity [dB]</sys:String>
+    <sys:String x:Key="Motion_Mouth_Microphone_Visualize">Show Volume</sys:String>
+    
     <sys:String x:Key="Motion_Face_EnableFaceTracking">Track Face</sys:String>
     <sys:String x:Key="Motion_Face_CameraName">Camera</sys:String>    
     <sys:String x:Key="Motion_Face_Calibration">Calibrate position</sys:String>    
@@ -215,13 +212,6 @@ If the face tracking works correctly, please ignore this warning.
     <sys:String x:Key="Motion_Eye_ApproxRotRangePrefix">(Eye bones will move about: </sys:String>
     <sys:String x:Key="Motion_Eye_ApproxRotRangeSuffix"> [deg])</sys:String>
     
-    <!-- Face : Mouth -->
-    <sys:String x:Key="Motion_Mouth">Mouth</sys:String>
-    <sys:String x:Key="Motion_Mouth_EnableLipSync">LipSync</sys:String>
-    <sys:String x:Key="Motion_Mouth_MicrophoneName">Microphone</sys:String>    
-    <sys:String x:Key="Motion_Mouth_Microphone_Sensitivity">Sensitivity [dB]</sys:String>
-    <sys:String x:Key="Motion_Mouth_Microphone_Visualize">Show Volume</sys:String>
-
     <!-- Face : BlendShape -->
     <sys:String x:Key="Motion_Face_BlendShape">BlendShape</sys:String>
     <sys:String x:Key="Motion_Face_NeutralClip">Default Face BlendShape</sys:String>    
@@ -245,7 +235,6 @@ camera movements following:
 - Mid click + drag: translate
 - Mouse wheel: forward/backward</sys:String>
     <sys:String x:Key="Layout_EnableFreeCameraMode">Free Camera Mode</sys:String>
-    <sys:String x:Key="Layout_CurrentCameraPosition">Camera Position (x, y, z, rx, ry, rz)</sys:String>
     <sys:String x:Key="Layout_Camera_ResetPosition">Reset Position</sys:String>
     <sys:String x:Key="Layout_Camera_Fov">FOV [deg]</sys:String>
     <sys:String x:Key="Layout_Camera_QuickSave">Quick Save</sys:String>
@@ -273,10 +262,7 @@ camera movements following:
     
     <!-- Devices -->
     <sys:String x:Key="Devices_Header">Devices</sys:String>
-    
-    <!-- Devices: Keyboard and mouse -->
-    <sys:String x:Key="Devices_Keyboard_Mouse_Header">Keyboard / Mouse</sys:String>
-    
+        
     <!-- Devices: MIDI -->
     <sys:String x:Key="Devices_Midi_Header">MIDI</sys:String>
     <sys:String x:Key="Devices_Midi_ReadEnable">Use MIDI Controller for VMagicMirror</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -46,11 +46,8 @@
     <sys:String x:Key="Home_Reset">リセット</sys:String>
     <sys:String x:Key="Home_LoadPrevSetting">旧バージョンの設定をロード</sys:String>
         
-    <sys:String x:Key="Home_OssLicense">OSS License</sys:String>
-
     <sys:String x:Key="Home_OtherSettings_Header">その他の設定</sys:String>
     <sys:String x:Key="Home_ActivateOnStartupHeader">Windowsの起動後にスタート</sys:String>
-    <sys:String x:Key="Home_ActivateOnStartup_OtherVerRegistered">※他バージョンのVMagicMirrorが自動で起動するように登録されています。チェックをオンにすると、このバージョンを起動するよう設定を上書きします。</sys:String>
     
     <!-- Streaming -->
     <sys:String x:Key="Streaming_Window">ウィンドウ</sys:String>
@@ -63,7 +60,6 @@
     <sys:String x:Key="Streaming_DeviceLayout_Reset">リセット</sys:String>
 
     <sys:String x:Key="Streaming_Screenshot">スクリーンショット</sys:String>
-    <sys:String x:Key="Streaming_Screenshot_Take">撮影</sys:String>
     <sys:String x:Key="Streaming_Screenshot_OpenSaveFolder">保存フォルダ...</sys:String>
     
     <!-- Ex.Tracker -->
@@ -89,7 +85,6 @@
     <sys:String x:Key="ExTracker_Source_iFacialMocap">iFacialMocap</sys:String>
     <sys:String x:Key="ExTracker_iFM_IpHint">iPhoneのIP Address...</sys:String>
     <sys:String x:Key="ExTracker_Source_HowToCollaborate">※アプリとの連携方法をチェック (Webページを開きます)</sys:String>
-    <sys:String x:Key="ExTracker_Source_RefreshReceiverSetting">ネットワーク環境を再チェック</sys:String>
 
     <sys:String x:Key="ExTracker_iFM_HasTrouble_Header">連携先アプリの設定を確認して下さい</sys:String>
     <sys:String x:Key="ExTracker_iFM_HasTrouble_OpenUrl">トラブルシューティングを開く(webページへ)</sys:String>
@@ -126,12 +121,6 @@
     <sys:String x:Key="Window_BackgroundImage_Load">ロード...</sys:String>
     <sys:String x:Key="Window_BackgroundImage_Clear">クリア</sys:String>
     
-    <sys:String x:Key="Window_EnableInitialPlacement">起動時に特定の位置へウィンドウを動かす</sys:String>
-    <sys:String x:Key="Window_InitialPositionX">X(画面左 = 0)</sys:String>
-    <sys:String x:Key="Window_InitialPositionY">Y(画面上 = 0)</sys:String>
-    <sys:String x:Key="Window_FetchUnityWindowPos">いまのウィンドウ位置を記憶</sys:String>
-    <sys:String x:Key="Window_MoveWindow">指定した位置へ移動</sys:String>
-    
     <sys:String x:Key="Window_TransparencySupport">キャラ透明化の詳細</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level">キャラの透明化レベル</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Alpha">透明になるときの透明度(32-255)</sys:String>
@@ -163,14 +152,11 @@
     <sys:String x:Key="Motion_Arm_ElbowCloseStrength">脇をしめる強さ [%]</sys:String>
     <sys:String x:Key="Motion_Arm_EnablePresenterMotion">プレゼン風に右手を動かす</sys:String>
     <sys:String x:Key="Motion_Arm_ShowPresentationPointer">補助ポインターを表示</sys:String>    
-    <sys:String x:Key="Motion_Arm_PresenterArmMotionScale">プレゼン動作サイズ[%]</sys:String>
     <sys:String x:Key="Motion_Arm_PresenterArmRadiusMin">プレゼン動作の最小半径 [cm]</sys:String>    
 
     <!-- Motion : Hand -->
     <sys:String x:Key="Motion_Hand">手・指</sys:String>
-    <sys:String x:Key="Motion_Hand_CharacterHandMotion">手の動き</sys:String>
     <sys:String x:Key="Motion_Hand_WristToHandTip">手首から指先までの長さ[cm]</sys:String>
-    <sys:String x:Key="Motion_Hand_WristToPalm">手首から手のひらまでの長さ[cm]</sys:String>
     <sys:String x:Key="Motion_Hand_HandYOffsetBasic">手の高さ調整[cm]</sys:String>
     <sys:String x:Key="Motion_Hand_HandYOffsetAfterKeyDown">(打鍵後)手の高さ調整[cm]</sys:String>
     
@@ -183,7 +169,16 @@
     <!-- NOTE: もともとMotionタブだったのを分断してる関係で命名ルールがちょっとアレです -->
     <!-- Face Motion -->
     <sys:String x:Key="Motion_Face">顔・表情</sys:String>
+
+    <!-- Face : Basic -->
     <sys:String x:Key="Motion_Face_Basics">基本の設定</sys:String>
+    
+    <sys:String x:Key="Motion_Mouth">口・リップシンク</sys:String>
+    <sys:String x:Key="Motion_Mouth_EnableLipSync">リップシンク</sys:String>
+    <sys:String x:Key="Motion_Mouth_MicrophoneName">マイク</sys:String>    
+    <sys:String x:Key="Motion_Mouth_Microphone_Sensitivity">マイク感度 [dB]</sys:String>
+    <sys:String x:Key="Motion_Mouth_Microphone_Visualize">音量をチェック</sys:String>
+
     <sys:String x:Key="Motion_Face_EnableFaceTracking">顔をトラッキング</sys:String>
     <sys:String x:Key="Motion_Face_CameraName">カメラ</sys:String>    
     <sys:String x:Key="Motion_Face_Calibration">姿勢・表情を補正</sys:String>    
@@ -218,12 +213,6 @@
     <sys:String x:Key="Motion_Eye_ApproxRotRangePrefix">(参考)目ボーンのおおよその可動範囲: </sys:String>
     <sys:String x:Key="Motion_Eye_ApproxRotRangeSuffix"> [deg]</sys:String>
     
-    <!-- Face : Mouth -->
-    <sys:String x:Key="Motion_Mouth">口・リップシンク</sys:String>
-    <sys:String x:Key="Motion_Mouth_EnableLipSync">リップシンク</sys:String>
-    <sys:String x:Key="Motion_Mouth_MicrophoneName">マイク</sys:String>    
-    <sys:String x:Key="Motion_Mouth_Microphone_Sensitivity">マイク感度 [dB]</sys:String>
-    <sys:String x:Key="Motion_Mouth_Microphone_Visualize">音量をチェック</sys:String>
     
     <!-- Face : BlendShape -->
     <sys:String x:Key="Motion_Face_BlendShape">ブレンドシェイプ</sys:String>
@@ -248,7 +237,6 @@
 - 中クリック + ドラッグ: 並行移動
 - マウスホイール: 前後に移動</sys:String>    
     <sys:String x:Key="Layout_EnableFreeCameraMode">フリーカメラモード</sys:String>
-    <sys:String x:Key="Layout_CurrentCameraPosition">カメラの位置(x, y, z, rx, ry, rz)</sys:String>
     <sys:String x:Key="Layout_Camera_ResetPosition">位置をリセット</sys:String>
     <sys:String x:Key="Layout_Camera_Fov">視野角 [deg]</sys:String>
     <sys:String x:Key="Layout_Camera_QuickSave">クイックセーブ</sys:String>
@@ -277,10 +265,7 @@
 
     <!-- Devices -->
     <sys:String x:Key="Devices_Header">デバイス接続</sys:String>
-    
-    <!-- Devices: Keyboard and mouse -->
-    <sys:String x:Key="Devices_Keyboard_Mouse_Header">キーボード・マウス</sys:String>
-    
+        
     <!-- Devices: MIDI -->
     <sys:String x:Key="Devices_Midi_Header">MIDI</sys:String>
     <sys:String x:Key="Devices_Midi_ReadEnable">MIDIコントローラ入力をVMagicMirrorで取得する</sys:String>

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -326,8 +326,13 @@ namespace Baku.VMagicMirrorConfig
 
             MessageIo.Start();
             LanguageSelector.Instance.Initialize(MessageSender);
+            Model.InitializeAvailableLanguage(
+                LanguageSelector.Instance.GetAdditionalSupportedLanguageNames()
+                );
+
             SettingFileIo.LoadSetting(SpecialFilePath.AutoSaveSettingFilePath, true);
-            //NOTE: 初回起動時だけカルチャベースで言語を設定するための処理がコレです
+
+            //NOTE: 初回起動時だけカルチャベースで言語を設定するための処理がコレ
             Model.InitializeLanguageIfNeeded();
 
             await MotionSetting.InitializeDeviceNamesAsync();


### PR DESCRIPTION
- ConfigAppフォルダにLocalizationフォルダを作る
- Localizatoinフォルダ以下へ、`English.xaml`を改変した`LangName.xaml`のようなファイルを置く
- VMagicMirrorをスタートする

の3手順によって日本語、英語以外の言語をサポートできるようになりました。

- 作成したファイルでローカライズが漏れている場合、ログファイルに情報を記載しつつ、英語のテキストへフォールバックします。
- 日本語、英語では従来どおり組み込み済みのローカライズファイルを使用します。

