### PR TITLE
"VRoid Perfect Sync"のオプションを削除

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/Entity/ExternalTrackerSetting.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/Entity/ExternalTrackerSetting.cs
@@ -16,7 +16,6 @@
         public bool EnableExternalTracking { get; set; } = false;
         public bool EnableExternalTrackerLipSync { get; set; } = true;
         public bool EnableExternalTrackerPerfectSync { get; set; } = false;
-        public bool UseVRoidDefaultForPerfectSync { get; set; } = false;
 
         // アプリ別の設定 (※今んとこIPを一方的に表示するだけなのであんまり難しい事はないです)
         public int TrackSourceType { get; set; } = 0;

--- a/VMagicMirrorConfig/VMagicMirrorConfig/Model/SettingSync/ExternalTrackerSettingSync.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/Model/SettingSync/ExternalTrackerSettingSync.cs
@@ -22,10 +22,6 @@ namespace Baku.VMagicMirrorConfig
                 setting.EnableExternalTrackerPerfectSync, b => SendMessage(factory.ExTrackerEnablePerfectSync(b))
                 );
 
-            UseVRoidDefaultForPerfectSync = new RProperty<bool>(
-                setting.UseVRoidDefaultForPerfectSync, b => SendMessage(factory.ExTrackerUseVRoidDefaultForPerfectSync(b))
-                );
-
             TrackSourceType = new RProperty<int>(setting.TrackSourceType, i => SendMessage(factory.ExTrackerSetSource(i)));
             //NOTE: このアドレスはコマンド実行時に使うため、書き換わってもメッセージは送らない
             IFacialMocapTargetIpAddress = new RProperty<string>(setting.IFacialMocapTargetIpAddress);
@@ -46,7 +42,6 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableExternalTracking { get; }
         public RProperty<bool> EnableExternalTrackerLipSync { get; }
         public RProperty<bool> EnableExternalTrackerPerfectSync { get; }
-        public RProperty<bool> UseVRoidDefaultForPerfectSync { get; }
 
         // アプリ別設定
         public RProperty<int> TrackSourceType { get; }
@@ -114,6 +109,5 @@ namespace Baku.VMagicMirrorConfig
             FaceSwitchSetting = ExternalTrackerFaceSwitchSetting.LoadDefault();
             SaveFaceSwitchSetting();
         }
-
     }
 }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanel/ExternalTrackerPanel.xaml
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/ControlPanel/ExternalTrackerPanel.xaml
@@ -53,7 +53,6 @@
                     <Grid.RowDefinitions>
                         <RowDefinition/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition/>
                     </Grid.RowDefinitions>
                     <CheckBox Grid.Row="0" 
                                   Margin="0"
@@ -84,13 +83,6 @@
                                            />
                         </StackPanel>
                     </Button>
-                    <CheckBox Grid.Row="2"
-                                  Margin="20,0,0,0" 
-                                  VerticalContentAlignment="Center"
-                                  Content="{DynamicResource ExTracker_PerfectSync_UseVRoidDefault}" 
-                                  IsEnabled="{Binding EnableExternalTrackerPerfectSync.Value}"
-                                  IsChecked="{Binding UseVRoidDefaultForPerfectSync.Value}"
-                                  />
                     <Button Grid.Row="0" Style="{StaticResource MaterialDesignOutlinedButton}"
                                 Padding="0"
                                 VerticalAlignment="Top"

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
@@ -112,7 +112,6 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableExternalTracking => _model.EnableExternalTracking;
         public RProperty<bool> EnableExternalTrackerLipSync => _model.EnableExternalTrackerLipSync;
         public RProperty<bool> EnableExternalTrackerPerfectSync => _model.EnableExternalTrackerPerfectSync;
-        public RProperty<bool> UseVRoidDefaultForPerfectSync => _model.UseVRoidDefaultForPerfectSync;
 
         public ActionCommand OpenPerfectSyncTipsUrlCommand { get; }
 


### PR DESCRIPTION
下記issueの対策です。
https://github.com/malaybaku/VMagicMirror/issues/534

「VRoid Studioのバージョン差でBlendShapeの割当が変わると破綻する」というのが実際に起きてしまったのを確認したため、オプション自体を削除します。

