### PR TITLE
起動後に読み込んだ設定に有効なEx.Trackerの設定がある場合は接続を試みる

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net;
 
 namespace Baku.VMagicMirrorConfig
 {
@@ -275,6 +276,21 @@ namespace Baku.VMagicMirrorConfig
             if (result)
             {
                 EnableExternalTracking.Value = false;
+            }
+        }
+
+        public void RefreshConnectionIfPossible()
+        {
+            //NOTE: 今は選択肢がiFacialMocapのみのため、そこをピンポイントで見に行く
+            if (!EnableExternalTracking.Value || !IsTrackSourceIFacialMocap)
+            {
+                return;
+            }
+
+            var ipAddress = IFacialMocapTargetIpAddress.Value;
+            if (IPAddress.TryParse(ipAddress, out _))
+            {
+                NetworkEnvironmentUtils.SendIFacialMocapDataReceiveRequest(ipAddress);
             }
         }
 

--- a/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -341,6 +341,9 @@ namespace Baku.VMagicMirrorConfig
             {
                 LoadSavedVRoidModel(Model.LastLoadedVRoidModelId, true);
             }
+
+            //NOTE: この処理はココでしか呼ばない = 起動直後限定の処理にしたくて意図的にやってます
+            ExternalTrackerSetting.RefreshConnectionIfPossible();
         }
 
         public void Dispose()


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/615

ポイント:

- 本当に起動後のみの挙動に限定する
- 設定ファイルのロードでは接続を試みない
- 外部トラッキング自体が無効だったり、連携先で「なし」を選択している場合は接続を試みない
- iFacialMocap用のテキスト欄にIPアドレスじゃない値が入ってる場合、エラーダイアログとかは出さない
