### PR TITLE
プレゼン用の強調ポインタがドロップダウンの邪魔になることがあるのを修正

### DIFF
--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/LargeMousePointerWindow.xaml.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/LargeMousePointerWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace Baku.VMagicMirrorConfig.LargePointer
     //NOTE: ウィンドウハンドルをゴリゴリ操作する + コレ以外のコードほぼないのでコードビハインド使う。
     public partial class LargeMousePointerWindow : Window
     {
-        private const int MouseTrackIntervalMillisec = 16;
+        private const int MouseTrackIntervalMillisec = 8;
         private const int MouseStopDisappearTimeMillisec = 6000;
         private const double OpacityChangeLerpFactor = 0.2;
 
@@ -66,7 +66,7 @@ namespace Baku.VMagicMirrorConfig.LargePointer
         private void SetClickThrough(IntPtr hWnd)
         {
             uint exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
-            SetWindowLong(hWnd, GWL_EXSTYLE, exStyle | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW);
+            SetWindowLong(hWnd, GWL_EXSTYLE, exStyle | WS_EX_TRANSPARENT);
         }
 
         private async Task LoopUpdateWindowPositionAsync(CancellationToken token)

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/NativeMethods.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/NativeMethods.cs
@@ -77,7 +77,7 @@ namespace Baku.VMagicMirrorConfig.LargePointer
 
         public static void SetWindowPosition(IntPtr hWnd, int x, int y) => SetWindowPos(
             hWnd, IntPtr.Zero, x, y, 0, 0, 
-            SetWindowPosFlags.IgnoreResize
+            SetWindowPosFlags.IgnoreResize | SetWindowPosFlags.DoNotActivate
             );
 
     }

--- a/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/NativeMethods.cs
+++ b/VMagicMirrorConfig/VMagicMirrorConfig/View/LargeMousePointer/NativeMethods.cs
@@ -32,11 +32,13 @@ namespace Baku.VMagicMirrorConfig.LargePointer
         public static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
 
         public static int GWL_STYLE => -16;
-        public static uint WS_POPUP => 0x80000000;
-        public static uint WS_VISIBLE => 0x10000000;
+        public static uint WS_POPUP => 0x8000_0000;
+        public static uint WS_VISIBLE => 0x1000_0000;
         public static int GWL_EXSTYLE => -20;
-        public static uint WS_EX_TRANSPARENT => 0x00000020;
-        public static uint WS_EX_TOOLWINDOW => 0x00000080;
+        public static uint WS_EX_TRANSPARENT => 0x0000_0020;
+        public static uint WS_EX_TOOLWINDOW => 0x0000_0080;
+        public static uint WS_EX_LAYERED => 0x0080_0000;
+        public static uint WS_EX_NOACTIVATE => 0x0800_0000;
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, SetWindowPosFlags uFlags);
@@ -73,7 +75,10 @@ namespace Baku.VMagicMirrorConfig.LargePointer
             IgnoreMoveAndResize = IgnoreMove | IgnoreResize,
         }
 
-        public static void SetWindowPosition(IntPtr hWnd, int x, int y) => SetWindowPos(hWnd, IntPtr.Zero, x, y, 0, 0, SetWindowPosFlags.IgnoreResize);
+        public static void SetWindowPosition(IntPtr hWnd, int x, int y) => SetWindowPos(
+            hWnd, IntPtr.Zero, x, y, 0, 0, 
+            SetWindowPosFlags.IgnoreResize
+            );
 
     }
 }


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/637

要するにドロップダウンウィンドウが「強調ポインタウィンドウがアクティブになった」という理由でクローズするのが原因だったので、アクティブにならないようにMoveWindowすればええやん、という結論になりました。

またポインタの位置更新頻度を上げてもCPU負荷にならないと判断できたため、移動頻度を60Hz付近から120Hz付近まで引き上げています。